### PR TITLE
Changed setting discovery options

### DIFF
--- a/benchmarks/src/main/java/io/scalecube/services/benchmarks/services/ServicesBenchmarksState.java
+++ b/benchmarks/src/main/java/io/scalecube/services/benchmarks/services/ServicesBenchmarksState.java
@@ -32,7 +32,7 @@ public class ServicesBenchmarksState extends BenchmarkState<ServicesBenchmarksSt
     node =
         Microservices.builder()
             .metrics(registry())
-            .seeds(seed.discovery().address())
+            .discovery(options -> options.seeds(seed.discovery().address()))
             .services(services)
             .startAwait();
 

--- a/examples/src/main/java/io/scalecube/examples/BootstrapExample.java
+++ b/examples/src/main/java/io/scalecube/examples/BootstrapExample.java
@@ -44,7 +44,7 @@ public class BootstrapExample {
     System.out.println("Start HelloWorldService with BusinessLogicFacade");
     final Microservices node1 =
         Microservices.builder()
-            .seeds(gateway.discovery().address())
+            .discovery(options -> options.seeds(gateway.discovery().address()))
             .services(
                 call ->
                     Collections.singletonList(
@@ -57,14 +57,14 @@ public class BootstrapExample {
     System.out.println("Start ServiceHello");
     final Microservices node2 =
         Microservices.builder()
-            .seeds(gateway.discovery().address())
+            .discovery(options -> options.seeds(gateway.discovery().address()))
             .services(new ServiceHelloImpl())
             .startAwait();
 
     System.out.println("Start ServiceWorld");
     final Microservices node3 =
         Microservices.builder()
-            .seeds(gateway.discovery().address())
+            .discovery(options -> options.seeds(gateway.discovery().address()))
             .services(new ServiceWorldImpl())
             .startAwait();
 

--- a/examples/src/main/java/io/scalecube/examples/helloworld/Example1.java
+++ b/examples/src/main/java/io/scalecube/examples/helloworld/Example1.java
@@ -26,7 +26,7 @@ public class Example1 {
     // Construct a ScaleCube node which joins the cluster hosting the Greeting Service
     Microservices microservices =
         Microservices.builder()
-            .seeds(seed.discovery().address())
+            .discovery(options -> options.seeds(seed.discovery().address()))
             .services(new GreetingServiceImpl())
             .startAwait();
 

--- a/examples/src/main/java/io/scalecube/examples/helloworld/Example2.java
+++ b/examples/src/main/java/io/scalecube/examples/helloworld/Example2.java
@@ -34,7 +34,7 @@ public class Example2 {
     // Construct a ScaleCube node which joins the cluster hosting the Greeting Service
     Microservices microservices =
         Microservices.builder()
-            .seeds(seed.discovery().address())
+            .discovery(options -> options.seeds(seed.discovery().address()))
             .services(new GreetingServiceImpl())
             .startAwait();
 

--- a/examples/src/main/java/io/scalecube/examples/orderbook/Example1.java
+++ b/examples/src/main/java/io/scalecube/examples/orderbook/Example1.java
@@ -33,7 +33,7 @@ public class Example1 {
 
     Microservices ms =
         Microservices.builder()
-            .seeds(gateway.discovery().address())
+            .discovery(options -> options.seeds(gateway.discovery().address()))
             .services(new DefaultMarketDataService())
             .startAwait();
 

--- a/services-api/src/main/java/io/scalecube/services/discovery/api/DiscoveryConfig.java
+++ b/services-api/src/main/java/io/scalecube/services/discovery/api/DiscoveryConfig.java
@@ -69,7 +69,7 @@ public class DiscoveryConfig {
     private String memberHost;
     private Integer memberPort;
 
-    public Builder seeds(Address[] seeds) {
+    public Builder seeds(Address... seeds) {
       this.seeds = seeds;
       return this;
     }

--- a/services-api/src/main/java/io/scalecube/services/discovery/api/DiscoveryConfig.java
+++ b/services-api/src/main/java/io/scalecube/services/discovery/api/DiscoveryConfig.java
@@ -6,6 +6,7 @@ import io.scalecube.transport.Address;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 public class DiscoveryConfig {
 
@@ -57,6 +58,20 @@ public class DiscoveryConfig {
 
   public static Builder builder() {
     return new Builder();
+  }
+
+  /**
+   * Returns a new discovery config builder and apply to it the given discovery options.
+   *
+   * @param discoveryOptions discovery options
+   * @return discovery config builder
+   */
+  public static Builder builder(Consumer<Builder> discoveryOptions) {
+    Builder builder = new Builder();
+    if (discoveryOptions != null) {
+      discoveryOptions.accept(builder);
+    }
+    return builder;
   }
 
   public static class Builder {

--- a/services-discovery/src/main/java/io/scalecube/services/discovery/ScalecubeServiceDiscovery.java
+++ b/services-discovery/src/main/java/io/scalecube/services/discovery/ScalecubeServiceDiscovery.java
@@ -69,7 +69,7 @@ public class ScalecubeServiceDiscovery implements ServiceDiscovery {
                             ClusterMetadataDecoder::encodeMetadata, service -> SERVICE_METADATA)))
             .build();
 
-    LOGGER.info("Join to cluster with {}", clusterConfig);
+    LOGGER.info("Start scalecube service discovery with config: {}", clusterConfig);
 
     CompletableFuture<Cluster> promise =
         Cluster.join(clusterConfig)
@@ -103,23 +103,23 @@ public class ScalecubeServiceDiscovery implements ServiceDiscovery {
   }
 
   private ClusterConfig.Builder clusterConfigBuilder(DiscoveryConfig config) {
-    Builder clusterConfig = ClusterConfig.builder();
+    Builder builder = ClusterConfig.builder();
     if (config.seeds() != null) {
-      clusterConfig.seedMembers(config.seeds());
+      builder.seedMembers(config.seeds());
     }
     if (config.port() != null) {
-      clusterConfig.port(config.port());
+      builder.port(config.port());
     }
     if (config.tags() != null) {
-      clusterConfig.metadata(config.tags());
+      builder.metadata(config.tags());
     }
     if (config.memberHost() != null) {
-      clusterConfig.memberHost(config.memberHost());
+      builder.memberHost(config.memberHost());
     }
     if (config.memberPort() != null) {
-      clusterConfig.memberPort(config.memberPort());
+      builder.memberPort(config.memberPort());
     }
-    return clusterConfig;
+    return builder;
   }
 
   private void init(Cluster cluster) {

--- a/services-discovery/src/main/java/io/scalecube/services/discovery/ScalecubeServiceDiscovery.java
+++ b/services-discovery/src/main/java/io/scalecube/services/discovery/ScalecubeServiceDiscovery.java
@@ -58,15 +58,21 @@ public class ScalecubeServiceDiscovery implements ServiceDiscovery {
   public Mono<ServiceDiscovery> start(DiscoveryConfig config) {
     configure(config);
 
-    clusterConfig.addMetadata(
-        this.serviceRegistry
-            .listServiceEndpoints()
-            .stream()
-            .collect(
-                Collectors.toMap(
-                    ClusterMetadataDecoder::encodeMetadata, service -> SERVICE_METADATA)));
+    ClusterConfig clusterConfig0 =
+        clusterConfig
+            .addMetadata(
+                this.serviceRegistry
+                    .listServiceEndpoints()
+                    .stream()
+                    .collect(
+                        Collectors.toMap(
+                            ClusterMetadataDecoder::encodeMetadata, service -> SERVICE_METADATA)))
+            .build();
+
+    LOGGER.info("Join to cluster with {}", clusterConfig0);
+
     CompletableFuture<Cluster> promise =
-        Cluster.join(clusterConfig.build())
+        Cluster.join(clusterConfig0)
             .whenComplete(
                 (success, error) -> {
                   if (error == null) {

--- a/services/src/main/java/io/scalecube/services/Microservices.java
+++ b/services/src/main/java/io/scalecube/services/Microservices.java
@@ -133,7 +133,6 @@ public class Microservices {
   }
 
   private Mono<Microservices> start() {
-
     return transportBootstrap
         .start(methodRegistry)
         .flatMap(

--- a/services/src/test/java/io/scalecube/services/ErrorFlowTest.java
+++ b/services/src/test/java/io/scalecube/services/ErrorFlowTest.java
@@ -28,13 +28,14 @@ public class ErrorFlowTest {
   public static void initNodes() {
     provider =
         Microservices.builder()
-            .discoveryPort(port.incrementAndGet())
+            .discovery(options -> options.port(port.incrementAndGet()))
             .services(new GreetingServiceImpl())
             .startAwait();
     consumer =
         Microservices.builder()
-            .discoveryPort(port.incrementAndGet())
-            .seeds(provider.discovery().address())
+            .discovery(
+                options ->
+                    options.seeds(provider.discovery().address()).port(port.incrementAndGet()))
             .startAwait();
   }
 

--- a/services/src/test/java/io/scalecube/services/ServiceCallRemoteTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceCallRemoteTest.java
@@ -61,7 +61,7 @@ public class ServiceCallRemoteTest extends BaseTest {
 
   private static Microservices serviceProvider() {
     return Microservices.builder()
-        .seeds(gateway.discovery().address())
+        .discovery(options -> options.seeds(gateway.discovery().address()))
         .services(new GreetingServiceImpl())
         .startAwait();
   }

--- a/services/src/test/java/io/scalecube/services/ServiceLocalTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceLocalTest.java
@@ -32,7 +32,7 @@ public class ServiceLocalTest extends BaseTest {
   public void setUp() {
     microservices =
         Microservices.builder()
-            .discoveryPort(port.incrementAndGet())
+            .discovery(options -> options.port(port.incrementAndGet()))
             .services(new GreetingServiceImpl())
             .startAwait();
   }

--- a/services/src/test/java/io/scalecube/services/ServiceRegistryEventsTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceRegistryEventsTest.java
@@ -25,13 +25,13 @@ public class ServiceRegistryEventsTest {
 
     Microservices ms1 =
         Microservices.builder()
-            .seeds(seed.discovery().address())
+            .discovery(options -> options.seeds(seed.discovery().address()))
             .services(new GreetingServiceImpl())
             .startAwait();
 
     Microservices ms2 =
         Microservices.builder()
-            .seeds(seed.discovery().address())
+            .discovery(options -> options.seeds(seed.discovery().address()))
             .services(new GreetingServiceImpl())
             .startAwait();
 

--- a/services/src/test/java/io/scalecube/services/ServiceRemoteTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceRemoteTest.java
@@ -60,7 +60,7 @@ public class ServiceRemoteTest extends BaseTest {
 
   private static Microservices serviceProvider() {
     return Microservices.builder()
-        .seeds(gateway.discovery().address())
+        .discovery(options -> options.seeds(gateway.discovery().address()))
         .services(new GreetingServiceImpl())
         .startAwait();
   }
@@ -191,7 +191,7 @@ public class ServiceRemoteTest extends BaseTest {
     // noinspection unused
     Microservices provider =
         Microservices.builder()
-            .seeds(gateway.discovery().address())
+            .discovery(options -> options.seeds(gateway.discovery().address()))
             .services(new CoarseGrainedServiceImpl()) // add service a and b
             .startAwait();
 
@@ -212,7 +212,10 @@ public class ServiceRemoteTest extends BaseTest {
     // Create microservices instance cluster.
     // noinspection unused
     Microservices provider =
-        Microservices.builder().seeds(gateway.discovery().address()).services(another).startAwait();
+        Microservices.builder()
+            .discovery(options -> options.seeds(gateway.discovery().address()))
+            .services(another)
+            .startAwait();
 
     // Get a proxy to the service api.
     CoarseGrainedService service = gateway.call().create().api(CoarseGrainedService.class);
@@ -229,7 +232,7 @@ public class ServiceRemoteTest extends BaseTest {
     // Create microservices instance cluster.
     Microservices ms =
         Microservices.builder()
-            .seeds(gateway.discovery().address())
+            .discovery(options -> options.seeds(gateway.discovery().address()))
             .services(another) // add service a and b
             .startAwait();
 
@@ -253,7 +256,7 @@ public class ServiceRemoteTest extends BaseTest {
     // Create microservices instance cluster.
     Microservices provider =
         Microservices.builder()
-            .seeds(gateway.discovery().address())
+            .discovery(options -> options.seeds(gateway.discovery().address()))
             .services(another) // add service a and b
             .startAwait();
 

--- a/services/src/test/java/io/scalecube/services/ServiceTransportTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceTransportTest.java
@@ -35,12 +35,16 @@ public class ServiceTransportTest {
   /** Setup. */
   @BeforeEach
   public void setUp() {
-    gateway = Microservices.builder().discoveryPort(port.incrementAndGet()).startAwait();
+    gateway =
+        Microservices.builder()
+            .discovery(options -> options.port(port.incrementAndGet()))
+            .startAwait();
 
     serviceNode =
         Microservices.builder()
-            .discoveryPort(port.incrementAndGet())
-            .seeds(gateway.discovery().address())
+            .discovery(
+                options ->
+                    options.seeds(gateway.discovery().address()).port(port.incrementAndGet()))
             .services(new SimpleQuoteService())
             .startAwait();
   }

--- a/services/src/test/java/io/scalecube/services/StreamingServiceTest.java
+++ b/services/src/test/java/io/scalecube/services/StreamingServiceTest.java
@@ -28,7 +28,7 @@ public class StreamingServiceTest extends BaseTest {
 
     node =
         Microservices.builder()
-            .seeds(gateway.discovery().address())
+            .discovery(options -> options.seeds(gateway.discovery().address()))
             .services(new SimpleQuoteService())
             .startAwait();
   }

--- a/services/src/test/java/io/scalecube/services/routings/RoutersTest.java
+++ b/services/src/test/java/io/scalecube/services/routings/RoutersTest.java
@@ -48,7 +48,7 @@ public class RoutersTest extends BaseTest {
     // Create microservices instance cluster.
     provider1 =
         Microservices.builder()
-            .seeds(gateway.discovery().address())
+            .discovery(options -> options.seeds(gateway.discovery().address()))
             .services(
                 ServiceInfo.fromServiceInstance(new GreetingServiceImpl(1))
                     .tag("ONLYFOR", "joe")
@@ -62,7 +62,7 @@ public class RoutersTest extends BaseTest {
     // Create microservices instance cluster.
     provider2 =
         Microservices.builder()
-            .seeds(gateway.discovery().address())
+            .discovery(options -> options.seeds(gateway.discovery().address()))
             .services(
                 ServiceInfo.fromServiceInstance(new GreetingServiceImpl(2))
                     .tag("ONLYFOR", "fransin")

--- a/services/src/test/java/io/scalecube/services/routings/ServiceTagsExample.java
+++ b/services/src/test/java/io/scalecube/services/routings/ServiceTagsExample.java
@@ -21,7 +21,7 @@ public class ServiceTagsExample {
 
     Microservices services1 =
         Microservices.builder()
-            .seeds(gateway.discovery().address())
+            .discovery(options -> options.seeds(gateway.discovery().address()))
             .services(
                 ServiceInfo.fromServiceInstance(new GreetingServiceImplA())
                     .tag("Weight", "0.3")
@@ -30,7 +30,7 @@ public class ServiceTagsExample {
 
     Microservices services2 =
         Microservices.builder()
-            .seeds(gateway.discovery().address())
+            .discovery(options -> options.seeds(gateway.discovery().address()))
             .services(
                 ServiceInfo.fromServiceInstance(new GreetingServiceImplB())
                     .tag("Weight", "0.7")


### PR DESCRIPTION
**Motivation:**
Recently I faced with the unexpected behavior of the Microservices' builder. I wanted to specify a member host and a seed address to my instance. 
```java
    Microservices.builder()
        .seeds(seeds)
        .discoveryConfig(
            DiscoveryConfig.builder()
                .memberHost(memberHost))
...
```
And this construction doesn't merge the specified props into the one config. It has lost the given seeds.
I think it will be better to make this more clear than it's now. And I'd like to propose to remove redundant setters (`seed`, `discoveryPort`) and use only one and this will look like:
```java
        Microservices.builder()
            .discovery(options -> options
                .seeds(seeds)
                .memberHost(memberHost))
...
```
it is a more clear approach.