### PR TITLE
Defer address lookup to subscription 

### DIFF
--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -322,14 +322,17 @@ public class ServiceCall {
   }
 
   private Mono<Address> addressLookup(ServiceMessage request) {
-    return Mono.fromCallable(() -> router.route(serviceRegistry, request)
-      .map(ServiceReference::address)
-      .orElseThrow(() -> noReachableMemberException(request)))
-      .doOnError(
-        t -> {
-          Optional<Object> dataOptional = Optional.ofNullable(request.data());
-          dataOptional.ifPresent(ReferenceCountUtil::safestRelease);
-        });
+    return Mono.fromCallable(
+            () ->
+                router
+                    .route(serviceRegistry, request)
+                    .map(ServiceReference::address)
+                    .orElseThrow(() -> noReachableMemberException(request)))
+        .doOnError(
+            t -> {
+              Optional<Object> dataOptional = Optional.ofNullable(request.data());
+              dataOptional.ifPresent(ReferenceCountUtil::safestRelease);
+            });
   }
 
   private static ServiceMessage toServiceMessage(MethodInfo methodInfo, Object... params) {

--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -322,15 +322,14 @@ public class ServiceCall {
   }
 
   private Mono<Address> addressLookup(ServiceMessage request) {
-    return router
-        .route(serviceRegistry, request)
-        .map(serviceReference -> Mono.just(serviceReference.address()))
-        .orElseGet(() -> Mono.error(noReachableMemberException(request)))
-        .doOnError(
-            t -> {
-              Optional<Object> dataOptional = Optional.ofNullable(request.data());
-              dataOptional.ifPresent(ReferenceCountUtil::safestRelease);
-            });
+    return Mono.fromCallable(() -> router.route(serviceRegistry, request)
+      .map(ServiceReference::address)
+      .orElseThrow(() -> noReachableMemberException(request)))
+      .doOnError(
+        t -> {
+          Optional<Object> dataOptional = Optional.ofNullable(request.data());
+          dataOptional.ifPresent(ReferenceCountUtil::safestRelease);
+        });
   }
 
   private static ServiceMessage toServiceMessage(MethodInfo methodInfo, Object... params) {

--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.function.Function;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
@@ -322,12 +323,13 @@ public class ServiceCall {
   }
 
   private Mono<Address> addressLookup(ServiceMessage request) {
-    return Mono.fromCallable(
-            () ->
-                router
-                    .route(serviceRegistry, request)
-                    .map(ServiceReference::address)
-                    .orElseThrow(() -> noReachableMemberException(request)))
+    Callable<Address> callable =
+        () ->
+            router
+                .route(serviceRegistry, request)
+                .map(ServiceReference::address)
+                .orElseThrow(() -> noReachableMemberException(request));
+    return Mono.fromCallable(callable)
         .doOnError(
             t -> {
               Optional<Object> dataOptional = Optional.ofNullable(request.data());

--- a/services/src/test/java/io/scalecube/services/ServiceCallRemoteTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceCallRemoteTest.java
@@ -23,7 +23,6 @@ import io.scalecube.services.sut.GreetingServiceImpl;
 import io.scalecube.services.sut.QuoteService;
 import io.scalecube.services.sut.SimpleQuoteService;
 import java.time.Duration;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -217,17 +216,16 @@ public class ServiceCallRemoteTest extends BaseTest {
             .call()
             .create()
             .requestMany(
-                ServiceMessage.builder().qualifier(QuoteService.NAME, "onlyOneAndThenNever")
-                  .data(null).build());
+                ServiceMessage.builder()
+                    .qualifier(QuoteService.NAME, "onlyOneAndThenNever")
+                    .data(null)
+                    .build());
 
     // Add service to cluster AFTER creating a call object.
     // (prove address lookup occur only after subscription)
     Microservices quotesService = serviceProvider(new SimpleQuoteService());
 
-    StepVerifier.create(quotes.take(1))
-        .expectNextCount(1)
-        .expectComplete()
-        .verify(timeout);
+    StepVerifier.create(quotes.take(1)).expectNextCount(1).expectComplete().verify(timeout);
 
     try {
       quotesService.shutdown();

--- a/services/src/test/java/io/scalecube/services/ServiceCallRemoteTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceCallRemoteTest.java
@@ -18,13 +18,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.scalecube.services.api.ServiceMessage;
 import io.scalecube.services.exceptions.ServiceException;
-import io.scalecube.services.sut.CoarseGrainedServiceImpl;
 import io.scalecube.services.sut.GreetingResponse;
 import io.scalecube.services.sut.GreetingServiceImpl;
-import java.time.Duration;
-
 import io.scalecube.services.sut.QuoteService;
 import io.scalecube.services.sut.SimpleQuoteService;
+import java.time.Duration;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -213,12 +212,16 @@ public class ServiceCallRemoteTest extends BaseTest {
   @Test
   public void test_service_address_lookup_occur_only_after_subscription() {
 
-    Flux<ServiceMessage> quotes = gateway.call().create().requestMany(ServiceMessage.builder()
-      .qualifier(QuoteService.NAME, "quotes")
-      .data(null)
-      .build());
+    Flux<ServiceMessage> quotes =
+        gateway
+            .call()
+            .create()
+            .requestMany(
+                ServiceMessage.builder().qualifier(QuoteService.NAME, "onlyOneAndThenNever")
+                  .data(null).build());
 
-    // Add service to cluster AFTER creating a call object. (prove address lookup occur only after subscription)
+    // Add service to cluster AFTER creating a call object.
+    // (prove address lookup occur only after subscription)
     Microservices quotesService = serviceProvider(new SimpleQuoteService());
 
     StepVerifier.create(quotes.take(1))


### PR DESCRIPTION
When executing a remote call i expect nothing to happen until i subscribe on the publisher (as per [reactor reference](http://projectreactor.io/docs/core/release/reference/#reactive.subscribe) )