### PR TITLE
[BugFix] Fixed NPE in ServiceCall (toString method)

### DIFF
--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -334,15 +334,17 @@ public class ServiceCall {
             getClass().getClassLoader(),
             new Class[] {serviceInterface},
             (proxy, method, params) -> {
+
+              Optional<Object> check =
+                      toStringOrEqualsOrHashCode(method.getName(), serviceInterface, params);
+              if (check.isPresent()) {
+                return check.get(); // toString, hashCode was invoked.
+              }
+
               final MethodInfo methodInfo = genericReturnTypes.get(method);
               final Type returnType = methodInfo.parameterizedReturnType();
               final boolean isServiceMessage = methodInfo.isRequestTypeServiceMessage();
 
-              Optional<Object> check =
-                  toStringOrEqualsOrHashCode(method.getName(), serviceInterface, params);
-              if (check.isPresent()) {
-                return check.get(); // toString, hashCode was invoked.
-              }
 
               switch (methodInfo.communicationMode()) {
                 case FIRE_AND_FORGET:


### PR DESCRIPTION
```
SLF4J: Failed toString() invocation on an object of type [com.sun.proxy.$Proxy24]
Reported exception:
java.lang.NullPointerException
	at io.scalecube.services.ServiceCall.lambda$api$13(ServiceCall.java:338)
	at com.sun.proxy.$Proxy24.toString(Unknown Source)
	at org.slf4j.helpers.MessageFormatter.safeObjectAppend(MessageFormatter.java:299)
	at org.slf4j.helpers.MessageFormatter.deeplyAppendParameter(MessageFormatter.java:271)
	at org.slf4j.helpers.MessageFormatter.arrayFormat(MessageFormatter.java:233)
	at org.slf4j.helpers.MessageFormatter.arrayFormat(MessageFormatter.java:173)
	at ch.qos.logback.classic.spi.LoggingEvent.getFormattedMessage(LoggingEvent.java:293)
	at ch.qos.logback.classic.spi.LoggingEvent.prepareForDeferredProcessing(LoggingEvent.java:206)
```

stacktrace