### PR TITLE
DI for RSocketTransport

### DIFF
--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServiceTransport.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServiceTransport.java
@@ -16,27 +16,37 @@ public class RSocketServiceTransport implements ServiceTransport {
 
   public static final RSocketServiceTransport INSTANCE = new RSocketServiceTransport();
 
-  private static final HeadersCodec HEADERS_CODEC = HeadersCodec.getInstance("application/json");
-  private static final ServiceMessageCodec MESSAGE_CODEC = new ServiceMessageCodec(HEADERS_CODEC);
-  private static final LoopResources LOOP_RESOURCES = LoopResources.create("rsocket-worker");
+  private final ServiceMessageCodec messageCodec;
+  private final LoopResources loopResources;
+
+  public RSocketServiceTransport() {
+    HeadersCodec headersCodec = HeadersCodec.getInstance("application/json");
+    messageCodec =  new ServiceMessageCodec(headersCodec);
+    loopResources =  LoopResources.create("rsocket-worker");
+  }
+
+  public RSocketServiceTransport(HeadersCodec headersCodec, LoopResources loopResources) {
+    this.messageCodec = new ServiceMessageCodec(headersCodec);
+    this.loopResources = loopResources;
+  }
 
   @Override
   public ClientTransport clientTransport(TransportResources resources) {
     return new RSocketClientTransport(
-        MESSAGE_CODEC,
+            messageCodec,
         ((RSocketTransportResources) resources)
             .workerPool()
             .<LoopResources>map(DelegatedLoopResources::newClientLoopResources)
-            .orElse(LOOP_RESOURCES));
+            .orElse(loopResources));
   }
 
   @Override
   public ServerTransport serverTransport(TransportResources resources) {
     return new RSocketServerTransport(
-        MESSAGE_CODEC,
+            messageCodec,
         ((RSocketTransportResources) resources)
             .workerPool()
             .<LoopResources>map(DelegatedLoopResources::newServerLoopResources)
-            .orElse(LOOP_RESOURCES));
+            .orElse(loopResources));
   }
 }

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServiceTransport.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServiceTransport.java
@@ -16,7 +16,6 @@ public class RSocketServiceTransport implements ServiceTransport {
 
   /**
    * Default Instance.
-   *
    */
   public static final RSocketServiceTransport INSTANCE = new RSocketServiceTransport();
 
@@ -25,7 +24,6 @@ public class RSocketServiceTransport implements ServiceTransport {
 
   /**
    * Default instance.
-   *
    */
   public RSocketServiceTransport() {
     HeadersCodec headersCodec = HeadersCodec.getInstance("application/json");
@@ -53,11 +51,11 @@ public class RSocketServiceTransport implements ServiceTransport {
   @Override
   public ClientTransport clientTransport(TransportResources resources) {
     return new RSocketClientTransport(
-            messageCodec,
-            ((RSocketTransportResources) resources)
-                    .workerPool()
-                    .<LoopResources>map(DelegatedLoopResources::newClientLoopResources)
-                    .orElse(loopResources));
+        messageCodec,
+        ((RSocketTransportResources) resources)
+            .workerPool()
+            .<LoopResources>map(DelegatedLoopResources::newClientLoopResources)
+            .orElse(loopResources));
   }
 
   /**
@@ -69,10 +67,10 @@ public class RSocketServiceTransport implements ServiceTransport {
   @Override
   public ServerTransport serverTransport(TransportResources resources) {
     return new RSocketServerTransport(
-            messageCodec,
-            ((RSocketTransportResources) resources)
-                    .workerPool()
-                    .<LoopResources>map(DelegatedLoopResources::newServerLoopResources)
-                    .orElse(loopResources));
+        messageCodec,
+        ((RSocketTransportResources) resources)
+            .workerPool()
+            .<LoopResources>map(DelegatedLoopResources::newServerLoopResources)
+            .orElse(loopResources));
   }
 }

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServiceTransport.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServiceTransport.java
@@ -14,39 +14,65 @@ import reactor.netty.resources.LoopResources;
  */
 public class RSocketServiceTransport implements ServiceTransport {
 
+  /**
+   * Default Instance.
+   *
+   */
   public static final RSocketServiceTransport INSTANCE = new RSocketServiceTransport();
 
   private final ServiceMessageCodec messageCodec;
   private final LoopResources loopResources;
 
+  /**
+   * Default instance.
+   *
+   */
   public RSocketServiceTransport() {
     HeadersCodec headersCodec = HeadersCodec.getInstance("application/json");
-    messageCodec =  new ServiceMessageCodec(headersCodec);
-    loopResources =  LoopResources.create("rsocket-worker");
+    messageCodec = new ServiceMessageCodec(headersCodec);
+    loopResources = LoopResources.create("rsocket-worker");
   }
 
+  /**
+   * Constructor with DI.
+   *
+   * @param headersCodec  user's headers codec
+   * @param loopResources loopResources
+   */
   public RSocketServiceTransport(HeadersCodec headersCodec, LoopResources loopResources) {
     this.messageCodec = new ServiceMessageCodec(headersCodec);
     this.loopResources = loopResources;
   }
 
+  /**
+   * Fabric method for client transport.
+   *
+   * @param resources service transport resources
+   * @return client's transport
+   */
   @Override
   public ClientTransport clientTransport(TransportResources resources) {
     return new RSocketClientTransport(
             messageCodec,
-        ((RSocketTransportResources) resources)
-            .workerPool()
-            .<LoopResources>map(DelegatedLoopResources::newClientLoopResources)
-            .orElse(loopResources));
+            ((RSocketTransportResources) resources)
+                    .workerPool()
+                    .<LoopResources>map(DelegatedLoopResources::newClientLoopResources)
+                    .orElse(loopResources));
   }
 
+  /**
+   * Fabric method for server transport.
+   *
+   * @param resources service transport resources
+   * @return server's transport
+   */
   @Override
   public ServerTransport serverTransport(TransportResources resources) {
     return new RSocketServerTransport(
             messageCodec,
-        ((RSocketTransportResources) resources)
-            .workerPool()
-            .<LoopResources>map(DelegatedLoopResources::newServerLoopResources)
-            .orElse(loopResources));
+            ((RSocketTransportResources) resources)
+                    .workerPool()
+                    .<LoopResources>map(DelegatedLoopResources::newServerLoopResources)
+                    .orElse(loopResources));
   }
 }


### PR DESCRIPTION
I added DI support for RSocketTransport. This was necessary to support DI in the project as a whole, as an alternative to the SPI mechanism.

RSocketServiceTransport depends on HeadersCodec. I want to use JacksonCodec. JaсsonCodec depends on ObjectMapper. The user should be able to configure the ObjectMapper.SPI does not allow this.