### PR TITLE
Updated rsocket version (RC)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <scalecube-benchmarks.version>1.2.2</scalecube-benchmarks.version>
     <scalecube-config.version>0.3.11</scalecube-config.version>
     <reactor.version>Californium-SR8</reactor.version>
-    <rsocket.version>0.12.2-RC2</rsocket.version>
+    <rsocket.version>0.12.2-RC4</rsocket.version>
     <metrics.version>3.1.2</metrics.version>
     <protostuff.version>1.6.0</protostuff.version>
     <netty.version>4.1.36.Final</netty.version>


### PR DESCRIPTION
Seems like rsocket release candidate (RC) version has lots of bugs so it pushes us to keep up the latest.

Also, the guys claim that they fixed keep-alive ack issue 