### PR TITLE
Align logging

### DIFF
--- a/services-examples-parent/services-examples/src/main/resources/log4j2.xml
+++ b/services-examples-parent/services-examples/src/main/resources/log4j2.xml
@@ -1,23 +1,66 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="warn">
+<Configuration>
+
+  <Properties>
+    <Property name="patternLayout">%level{length=1} %d{ISO8601} %c{1.} %m [%t]%n</Property>
+  </Properties>
 
   <Appenders>
-    <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%level{length=1} %date{MMdd-HHmm:ss,SSS} %logger{1.} %message [%thread]%n</pattern>
-      </PatternLayout>
+    <Console name="STDOUT" target="SYSTEM_OUT">
+      <PatternLayout pattern="${patternLayout}"/>
     </Console>
+
+    <RollingFile name="FILE" fileName="logs/server.log" filePattern="logs/server-%i.log">
+      <PatternLayout pattern="${patternLayout}"/>
+      <Policies>
+        <OnStartupTriggeringPolicy/>
+        <SizeBasedTriggeringPolicy size="100 MB"/>
+      </Policies>
+      <DefaultRolloverStrategy max="1000"/>
+    </RollingFile>
+
+    <Console name="JSON_STDOUT" target="SYSTEM_OUT">
+      <JSONLayout compact="true" eventEol="true" properties="true" stacktraceAsString="true">
+        <KeyValuePair key="date" value="$${date:yyyy-MM-dd'T'HH:mm:ss.SSSXXX}"/>
+        <KeyValuePair key="service" value="configuration-service"/>
+        <KeyValuePair key="ddsource" value="configuration-service"/>
+        <KeyValuePair key="ddtags" value="${env:TAGS}"/>
+        <KeyValuePair key="host" value="${env:NODENAME}"/>
+      </JSONLayout>
+    </Console>
+
+    <RollingFile name="JSON_FILE" fileName="logs/server.log" filePattern="logs/server-%i.log">
+      <JSONLayout compact="true" eventEol="true" properties="true" stacktraceAsString="true">
+        <KeyValuePair key="date" value="$${date:yyyy-MM-dd'T'HH:mm:ss.SSSXXX}"/>
+        <KeyValuePair key="service" value="configuration-service"/>
+        <KeyValuePair key="ddsource" value="configuration-service"/>
+        <KeyValuePair key="ddtags" value="${env:TAGS}"/>
+        <KeyValuePair key="host" value="${env:NODENAME}"/>
+      </JSONLayout>
+      <Policies>
+        <OnStartupTriggeringPolicy/>
+        <SizeBasedTriggeringPolicy size="100 MB"/>
+      </Policies>
+      <DefaultRolloverStrategy max="1000"/>
+    </RollingFile>
   </Appenders>
 
   <Loggers>
-    <Logger name="io.netty" level="info"/>
-    <Logger name="reactor.netty" level="info"/>
-    <Logger name="io.scalecube.transport" level="info"/>
-    <Logger name="io.scalecube.cluster" level="info"/>
-    <Logger name="io.scalecube.services" level="info"/>
+    <Logger name="io.scalecube.seed" level="${env:seedLogLevel:-INFO}"/>
+    <Logger name="io.scalecube.services" level="${env:servicesLogLevel:-INFO}"/>
+    <Logger name="io.scalecube.transport" level="${env:servicesTransportLogLevel:-DEBUG}"/>
+    <Logger name="io.scalecube.cluster" level="${env:clusterLogLevel:-INFO}"/>
+    <Logger name="io.scalecube.config" level="${env:configLogLevel:-INFO}"/>
+    <Logger name="reactor.util" level="${env:reactorUtilLogLevel:-WARN}"/>
+    <Logger name="reactor.core" level="${env:reactorCoreLogLevel:-WARN}"/>
+    <Logger name="reactor.netty" level="${env:reactorNettyLogLevel:-WARN}"/>
+    <Logger name="io.netty" level="${env:nettyLogLevel:-WARN}"/>
+    <logger name="io.rsocket.transport.netty" level="${env:rsocketTransportNettyLogLevel:-WARN}"/>
+    <logger name="io.rsocket.FrameLogger" level="${env:rsocketFrameLoggerLogLevel:-WARN}"/>
+    <logger name="io.rsocket" level="${env:rsocketLogLevel:-INFO}"/>
 
-    <Root level="info">
-      <AppenderRef ref="console"/>
+    <Root level="${env:logLevel:-DEBUG}">
+      <AppenderRef ref="${env:logAppender:-STDOUT}"/>
     </Root>
   </Loggers>
 


### PR DESCRIPTION
What is done:
1) only one log file will be used for logging (`log4j.xml`)
2) to change the log level, log appender, output destination or something else --> need to use SYSTEM variable, there are available system variables: 

| System variables | Description | Default value  |
|---|---|---|
| `seedLogLevel` | to specify log level for `io.scalecube.seed`  | `INFO` | 
| `servicesLogLevel` | to specify log level for `io.scalecube.services` | `INFO` | 
| `servicesTransportLogLevel` | to specify log level for `io.scalecube.transport` | `DEBUG` | 
| `clusterLogLevel` | to specify log level for `io.scalecube.cluster` | `INFO` | 
| `configLogLevel` | to specify log level for `io.scalecube.config` | `INFO` | 
| `reactorUtilLogLevel` | to specify log level for `reactor.util` | `WARN` | 
| `reactorCoreLogLevel` | to specify log level for `reactor.core` | `WARN` | 
| `reactorNettyLogLevel` | to specify log level for `reactor.netty` | `WARN` | 
| `nettyLogLevel` | to specify log level for `io.netty` | `WARN` | 
| `rsocketTransportNettyLogLevel` | to specify log level for `io.rsocket.transport.netty` | `WARN` | 
| `rsocketFrameLoggerLogLevel` | to specify log level for `io.rsocket.FrameLogger` | `WARN` | 
| `rsocketLogLevel` | to specify log level for `io.rsocket` | `INFO` | 
| `logLevel` | to specify default log level | `DEBUG` | 
| `logAppender` | destination where append logs | `STDOUT` | 

3) there are log appenders, to specify it in the system variable like `logAppender`: 

| Name | Description | 
|---|---|
| `STDOUT` | to print logs to the console in the general format  | 
| `JSON_STDOUT` | to print logs to the console in the JSON format (for datadog)  | 
| `FILE` | to print logs to a file in the general format | 
| `JSON_FILE` | to print logs to a file in the JSON format (for datadog) | 