### PR TITLE
Refactor request releaser

### DIFF
--- a/services-api/src/main/java/io/scalecube/services/methods/ServiceMethodRegistry.java
+++ b/services-api/src/main/java/io/scalecube/services/methods/ServiceMethodRegistry.java
@@ -7,8 +7,6 @@ public interface ServiceMethodRegistry {
 
   void registerService(ServiceInfo serviceInfo);
 
-  boolean containsInvoker(String qualifier);
-
   ServiceMethodInvoker getInvoker(String qualifier);
 
   List<ServiceMethodInvoker> listInvokers();

--- a/services-api/src/test/java/io/scalecube/services/methods/ServiceMethodInvokerTest.java
+++ b/services-api/src/test/java/io/scalecube/services/methods/ServiceMethodInvokerTest.java
@@ -60,7 +60,7 @@ class ServiceMethodInvokerTest {
     ServiceMessage message =
         ServiceMessage.builder().qualifier(qualifierPrefix + methodName).build();
 
-    StepVerifier.create(serviceMethodInvoker.invokeOne(message, requestReleaser)).verifyComplete();
+    StepVerifier.create(serviceMethodInvoker.invokeOne(message)).verifyComplete();
   }
 
   @Test
@@ -94,7 +94,7 @@ class ServiceMethodInvokerTest {
     ServiceMessage message =
         ServiceMessage.builder().qualifier(qualifierPrefix + methodName).build();
 
-    StepVerifier.create(serviceMethodInvoker.invokeMany(message, requestReleaser)).verifyComplete();
+    StepVerifier.create(serviceMethodInvoker.invokeMany(message)).verifyComplete();
   }
 
   @Test
@@ -129,7 +129,7 @@ class ServiceMethodInvokerTest {
         ServiceMessage.builder().qualifier(qualifierPrefix + methodName).build();
 
     StepVerifier.create(
-            serviceMethodInvoker.invokeBidirectional(Flux.just(message), requestReleaser))
+            serviceMethodInvoker.invokeBidirectional(Flux.just(message)))
         .verifyComplete();
   }
 
@@ -165,7 +165,7 @@ class ServiceMethodInvokerTest {
         ServiceMessage.builder().qualifier(qualifierPrefix + methodName).build();
 
     // invokeOne
-    final Mono<ServiceMessage> invokeOne = serviceMethodInvoker.invokeOne(message, requestReleaser);
+    final Mono<ServiceMessage> invokeOne = serviceMethodInvoker.invokeOne(message);
 
     StepVerifier.create(invokeOne).assertNext(ServiceMessage::isError).verifyComplete();
   }
@@ -202,7 +202,7 @@ class ServiceMethodInvokerTest {
         ServiceMessage.builder().qualifier(qualifierPrefix + methodName).build();
 
     final Flux<ServiceMessage> invokeOne =
-        serviceMethodInvoker.invokeMany(message, requestReleaser);
+        serviceMethodInvoker.invokeMany(message);
 
     StepVerifier.create(invokeOne).assertNext(ServiceMessage::isError).verifyComplete();
   }
@@ -240,7 +240,7 @@ class ServiceMethodInvokerTest {
 
     // invokeOne
     final Flux<ServiceMessage> invokeOne =
-        serviceMethodInvoker.invokeBidirectional(Flux.just(message), requestReleaser);
+        serviceMethodInvoker.invokeBidirectional(Flux.just(message));
 
     StepVerifier.create(invokeOne).assertNext(ServiceMessage::isError).verifyComplete();
   }

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServiceAcceptor.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServiceAcceptor.java
@@ -54,7 +54,7 @@ public class RSocketServiceAcceptor implements SocketAcceptor {
           .flatMap(
               message -> {
                 ServiceMethodInvoker methodInvoker = methodRegistry.getInvoker(message.qualifier());
-                return methodInvoker.invokeOne(message, requestReleaser);
+                return methodInvoker.invokeOne(message);
               })
           .map(this::toPayload);
     }
@@ -66,7 +66,7 @@ public class RSocketServiceAcceptor implements SocketAcceptor {
           .flatMapMany(
               message -> {
                 ServiceMethodInvoker methodInvoker = methodRegistry.getInvoker(message.qualifier());
-                return methodInvoker.invokeMany(message, requestReleaser);
+                return methodInvoker.invokeMany(message);
               })
           .map(this::toPayload);
     }
@@ -82,7 +82,7 @@ public class RSocketServiceAcceptor implements SocketAcceptor {
                   validateRequest(message);
                   ServiceMethodInvoker methodInvoker =
                       methodRegistry.getInvoker(message.qualifier());
-                  return methodInvoker.invokeBidirectional(messages, requestReleaser);
+                  return methodInvoker.invokeBidirectional(messages);
                 }
                 return messages;
               })

--- a/services/src/main/java/io/scalecube/services/Microservices.java
+++ b/services/src/main/java/io/scalecube/services/Microservices.java
@@ -242,11 +242,9 @@ public final class Microservices {
    * @return new {@code ServiceCall} instance.
    */
   public ServiceCall call() {
-    return new ServiceCall()
-        .transport(transportBootstrap.clientTransport)
-        .serviceRegistry(serviceRegistry)
-        .methodRegistry(methodRegistry)
+    return new ServiceCall(transportBootstrap.clientTransport, methodRegistry, serviceRegistry)
         .contentType(contentType)
+        .errorMapper(DefaultErrorMapper.INSTANCE)
         .router(Routers.getRouter(RoundRobinServiceRouter.class));
   }
 

--- a/services/src/main/java/io/scalecube/services/methods/ServiceMethodRegistryImpl.java
+++ b/services/src/main/java/io/scalecube/services/methods/ServiceMethodRegistryImpl.java
@@ -63,11 +63,6 @@ public final class ServiceMethodRegistryImpl implements ServiceMethodRegistry {
   }
 
   @Override
-  public boolean containsInvoker(String qualifier) {
-    return methodInvokers.containsKey(qualifier);
-  }
-
-  @Override
   public ServiceMethodInvoker getInvoker(String qualifier) {
     return methodInvokers.get(qualifier);
   }


### PR DESCRIPTION
**Motivation**

Code cleanup of obvious design mistakes.

**Updates**

* Refactor request releaser (only left in rsocket server)
* Removed `containsInvoker` (to have one-less lookup in hash map by string)