### PR TITLE
Fixed an error caused by Reflect.isRequestTypeServiceMessage() returning false on Publisher<ServiceMessage>

### DIFF
--- a/services-api/src/main/java/io/scalecube/services/Reflect.java
+++ b/services-api/src/main/java/io/scalecube/services/Reflect.java
@@ -115,9 +115,18 @@ public class Reflect {
    * @return true if the first parameter of method is ServiceMessage, otherwise false
    */
   public static boolean isRequestTypeServiceMessage(Method method) {
-    Class<?>[] parameterTypes = method.getParameterTypes();
+    Type[] parameterTypes = method.getGenericParameterTypes();
 
-    return parameterTypes.length > 0 && ServiceMessage.class.equals(parameterTypes[0]);
+    if (parameterTypes.length < 1) {
+      return false;
+    }
+
+    if (parameterTypes[0] instanceof ParameterizedType) {
+      ParameterizedType parameterizedType = (ParameterizedType) parameterTypes[0];
+      return ServiceMessage.class.equals(parameterizedType.getActualTypeArguments()[0]);
+    }
+
+    return ServiceMessage.class.equals(parameterTypes[0]);
   }
 
   /**

--- a/services/src/test/java/io/scalecube/services/ServiceRemoteTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceRemoteTest.java
@@ -27,10 +27,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
-import reactor.core.publisher.EmitterProcessor;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Hooks;
-import reactor.core.publisher.Mono;
+import reactor.core.publisher.*;
 import reactor.test.StepVerifier;
 
 public class ServiceRemoteTest extends BaseTest {
@@ -370,6 +367,25 @@ public class ServiceRemoteTest extends BaseTest {
   }
 
   @Test
+  public void test_remote_bidi_greeting_message_expect_IllegalArgumentException() {
+
+    // get a proxy to the service api.
+    GreetingService service = createProxy();
+
+    // call the service. bidiThrowingGreeting
+    Flux<GreetingResponse> responses =
+            service.bidiGreetingIllegalArgumentExceptionMessage(
+                    Mono.just(ServiceMessage.builder()
+                            .data(new GreetingRequest("IllegalArgumentException")).build()))
+            .map(ServiceMessage::data);
+
+    // call the service.
+    StepVerifier.create(responses)
+            .expectErrorMessage("IllegalArgumentException")
+            .verify(Duration.ofSeconds(3));
+  }
+
+  @Test
   public void test_remote_bidi_greeting_expect_NotAuthorized() {
 
     // get a proxy to the service api.
@@ -387,6 +403,25 @@ public class ServiceRemoteTest extends BaseTest {
     StepVerifier.create(responses)
         .expectErrorMessage("Not authorized")
         .verify(Duration.ofSeconds(3));
+  }
+
+  @Test
+  public void test_remote_bidi_greeting_message_expect_NotAuthorized() {
+
+    // get a proxy to the service api.
+    GreetingService service = createProxy();
+
+    DirectProcessor<GreetingRequest> requests = DirectProcessor.create();
+
+    // call the service.
+    Flux<GreetingResponse> responses = service.bidiGreetingNotAuthorizedMessage(
+            requests.map(request -> ServiceMessage.builder().data(request).build()))
+            .map(ServiceMessage::data);
+
+    StepVerifier.create(responses)
+            .then(() -> requests.onNext(new GreetingRequest("joe-1")))
+            .expectErrorMessage("Not authorized")
+            .verify(Duration.ofSeconds(3));
   }
 
   @Test
@@ -413,6 +448,31 @@ public class ServiceRemoteTest extends BaseTest {
         .expectNextMatches(resp -> resp.getResult().equals(" hello to: joe-3"))
         .expectComplete()
         .verify(Duration.ofSeconds(3));
+  }
+
+  @Test
+  public void test_remote_bidi_greeting_message_expect_GreetingResponse() {
+
+    // get a proxy to the service api.
+    GreetingService service = createProxy();
+
+    UnicastProcessor<GreetingRequest> requests = UnicastProcessor.create();
+
+    // call the service.
+    Flux<GreetingResponse> responses = service.bidiGreetingMessage(requests
+            .map(request -> ServiceMessage.builder().data(request).build()))
+            .map(ServiceMessage::data);
+
+    StepVerifier.create(responses)
+            .then(() -> requests.onNext(new GreetingRequest("joe-1")))
+            .expectNextMatches(resp -> resp.getResult().equals(" hello to: joe-1"))
+            .then(() -> requests.onNext(new GreetingRequest("joe-2")))
+            .expectNextMatches(resp -> resp.getResult().equals(" hello to: joe-2"))
+            .then(() -> requests.onNext(new GreetingRequest("joe-3")))
+            .expectNextMatches(resp -> resp.getResult().equals(" hello to: joe-3"))
+            .then(() -> requests.onComplete())
+            .expectComplete()
+            .verify(Duration.ofSeconds(3));
   }
 
   @Test

--- a/services/src/test/java/io/scalecube/services/sut/GreetingService.java
+++ b/services/src/test/java/io/scalecube/services/sut/GreetingService.java
@@ -71,10 +71,25 @@ public interface GreetingService {
   Flux<GreetingResponse> bidiGreeting(Publisher<GreetingRequest> request);
 
   @ServiceMethod
+  @RequestType(GreetingRequest.class)
+  @ResponseType(GreetingResponse.class)
+  Flux<ServiceMessage> bidiGreetingMessage(Publisher<ServiceMessage> requests);
+
+  @ServiceMethod
   Flux<GreetingResponse> bidiGreetingNotAuthorized(Flux<GreetingRequest> request);
 
   @ServiceMethod
+  @RequestType(GreetingRequest.class)
+  @ResponseType(GreetingResponse.class)
+  Flux<ServiceMessage> bidiGreetingNotAuthorizedMessage(Publisher<ServiceMessage> requests);
+
+  @ServiceMethod
   Flux<GreetingResponse> bidiGreetingIllegalArgumentException(Publisher<GreetingRequest> request);
+
+  @ServiceMethod
+  @RequestType(GreetingRequest.class)
+  @ResponseType(GreetingResponse.class)
+  Flux<ServiceMessage> bidiGreetingIllegalArgumentExceptionMessage(Publisher<ServiceMessage> requests);
 
   @ServiceMethod
   Mono<GreetingResponse> greetingMonoEmpty(GreetingRequest request);

--- a/services/src/test/java/io/scalecube/services/sut/GreetingServiceImpl.java
+++ b/services/src/test/java/io/scalecube/services/sut/GreetingServiceImpl.java
@@ -79,13 +79,32 @@ public final class GreetingServiceImpl implements GreetingService {
   }
 
   @Override
+  public Flux<ServiceMessage> bidiGreetingMessage(Publisher<ServiceMessage> requests) {
+    return Flux.from(requests).map(request -> {
+      GreetingRequest data = request.data();
+      GreetingResponse resp = new GreetingResponse(" hello to: " + data.getName(), "1");
+      return ServiceMessage.builder().data(resp).build();
+    });
+  }
+
+  @Override
   public Flux<GreetingResponse> bidiGreetingNotAuthorized(Flux<GreetingRequest> request) {
+    return Flux.error(new ForbiddenException("Not authorized"));
+  }
+
+  @Override
+  public Flux<ServiceMessage> bidiGreetingNotAuthorizedMessage(Publisher<ServiceMessage> requests) {
     return Flux.error(new ForbiddenException("Not authorized"));
   }
 
   @Override
   public Flux<GreetingResponse> bidiGreetingIllegalArgumentException(
       Publisher<GreetingRequest> request) {
+    throw new IllegalArgumentException("IllegalArgumentException");
+  }
+
+  @Override
+  public Flux<ServiceMessage> bidiGreetingIllegalArgumentExceptionMessage(Publisher<ServiceMessage> requests) {
     throw new IllegalArgumentException("IllegalArgumentException");
   }
 


### PR DESCRIPTION
When using dispatcher and REQUEST_CHANNEL together like follow:
```
  @ServiceMethod
  @RequestType(GreetingRequest.class)
  @ResponseType(GreetingResponse.class)
  Flux<ServiceMessage> bidiGreetingMessage(Publisher<ServiceMessage> requests);
```
When called it will have error `GreetingRequest cannot be cast to ServiceMessage`.
The error happens at `ServiceMethodInvoker::toRequest`:
```
return methodInfo.isRequestTypeServiceMessage() ? request : request.data();
```
In this case, it should return request, but the isRequestTypeServiceMessage() returns false, and request.data() is returned.

This PR tries to fix this by checking the actual type arguments, then returns true. 

Please take a look if this is expected behavior or should be fixed.

Thank you.
