### PR TITLE
Always authenticate connections

### DIFF
--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServiceAcceptor.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServiceAcceptor.java
@@ -98,7 +98,7 @@ public class RSocketServiceAcceptor implements SocketAcceptor {
   }
 
   private Mono<Object> authenticate(RSocket rsocket, ConnectionSetup connectionSetup) {
-    if (authenticator == null || connectionSetup == null || !connectionSetup.hasCredentials()) {
+    if (authenticator == null || connectionSetup == null) {
       return Mono.empty();
     }
     return authenticator


### PR DESCRIPTION
If an authenticator is present, always authenticate connections regardless of whether credentials are present because at the moment if a client wants to bypass authentication they can just not specify any credentials.