### PR TITLE
Build with Java 17 & Invoke default methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,8 @@
   </scm>
 
   <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+
     <scalecube-cluster.version>2.6.12</scalecube-cluster.version>
     <scalecube-commons.version>1.0.18</scalecube-commons.version>
     <scalecube-security.version>1.0.24</scalecube-security.version>

--- a/services-api/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services-api/src/main/java/io/scalecube/services/ServiceCall.java
@@ -308,7 +308,7 @@ public class ServiceCall {
                   return check.get(); // toString, hashCode was invoked.
                 }
 
-                if(method.isDefault()) {
+                if (method.isDefault()) {
                   return InvocationHandler.invokeDefault(proxy, method, params);
                 }
 

--- a/services-api/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services-api/src/main/java/io/scalecube/services/ServiceCall.java
@@ -301,11 +301,15 @@ public class ServiceCall {
             new Class[] {serviceInterface},
             new InvocationHandler() {
               @Override
-              public Object invoke(Object proxy, Method method, Object[] params) {
+              public Object invoke(Object proxy, Method method, Object[] params) throws Throwable {
                 Optional<Object> check =
                     toStringOrEqualsOrHashCode(method.getName(), serviceInterface, params);
                 if (check.isPresent()) {
                   return check.get(); // toString, hashCode was invoked.
+                }
+
+                if(method.isDefault()) {
+                  return InvocationHandler.invokeDefault(proxy, method, params);
                 }
 
                 final MethodInfo methodInfo = genericReturnTypes.get(method);


### PR DESCRIPTION
This allows default methods on service interfaces to be called, although it requires at least Java 16 to function as it makes use of [InvocationHandler#invokeDefault](https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/lang/reflect/InvocationHandler.html#invokeDefault(java.lang.Object,java.lang.reflect.Method,java.lang.Object...)).