### PR TITLE
Enhnance file-upload

### DIFF
--- a/services-gateway/src/test/java/io/scalecube/services/gateway/files/FileUploadTest.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/files/FileUploadTest.java
@@ -21,6 +21,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import okhttp3.MediaType;
 import okhttp3.MultipartBody;
 import okhttp3.OkHttpClient;
@@ -31,10 +33,14 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Mono;
 
 public class FileUploadTest {
+
+  private static final int MAX_SIZE = 15 * 1024 * 1024;
+  private static final int SIZE_OVER_LIMIT = MAX_SIZE + 1024 * 1024;
 
   private static Microservices gateway;
   private static Microservices microservices;
@@ -56,7 +62,12 @@ public class FileUploadTest {
                             .options(opts -> opts.metadata(serviceEndpoint)))
                 .transport(
                     () -> new RSocketServiceTransport().credentialsSupplier(credentialsSupplier))
-                .gateway(() -> HttpGateway.builder().id("HTTP").build()));
+                .gateway(
+                    () ->
+                        HttpGateway.builder()
+                            .id("HTTP")
+                            .formDecoderBuilder(builder -> builder.maxSize(MAX_SIZE))
+                            .build()));
 
     microservices =
         Microservices.start(
@@ -85,9 +96,9 @@ public class FileUploadTest {
     }
   }
 
-  @ParameterizedTest(name = "Upload file of size {0} bytes")
-  @ValueSource(longs = {0, 64, 512, 1024, 1024 * 1024, 10 * 1024 * 1024})
-  public void uploadSuccessfully(long fileSize) throws Exception {
+  @ParameterizedTest(name = "Upload successfully, size: {0} bytes")
+  @ValueSource(longs = {0, 512, 1024, 1024 * 1024, 10 * 1024 * 1024})
+  void uploadSuccessfully(long fileSize) throws Exception {
     final var client = new OkHttpClient();
     final var file = generateFile(Files.createTempFile("export_report_", null), fileSize);
 
@@ -113,10 +124,11 @@ public class FileUploadTest {
     }
   }
 
-  @Test
-  public void uploadFailed() throws Exception {
+  @ParameterizedTest
+  @MethodSource("uploadFailedSource")
+  void uploadFailed(UploadFailedArgs args) throws Exception {
     final var client = new OkHttpClient();
-    final var file = generateFile(Files.createTempFile("export_report_", null), 1024);
+    final var file = generateFile(Files.createTempFile("export_report_", null), args.fileSize());
 
     final var body =
         new MultipartBody.Builder()
@@ -135,8 +147,44 @@ public class FileUploadTest {
       assertEquals(
           HttpResponseStatus.INTERNAL_SERVER_ERROR.code(), response.code(), "response.code");
       assertEquals(
-          "{\"errorCode\":500,\"errorMessage\":\"Upload report failed: %s\"}"
-              .formatted(file.getName()),
+          "{\"errorCode\":%s,\"errorMessage\":\"%s\"}"
+              .formatted(args.errorCode(), args.errorMessageFunc().apply(file)),
+          response.body().string(),
+          "response.body");
+    }
+  }
+
+  @Test
+  void onlySingleFileAllowed() throws Exception {
+    final var client = new OkHttpClient();
+
+    final var fileSize = 1024 * 1024;
+    final var file1 = generateFile(Files.createTempFile("export_report_1_", null), fileSize);
+    final var file2 = generateFile(Files.createTempFile("export_report_2_", null), fileSize);
+
+    final var body =
+        new MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart(
+                "file",
+                file1.getName(),
+                RequestBody.create(file1, MediaType.get("application/text")))
+            .addFormDataPart(
+                "file",
+                file2.getName(),
+                RequestBody.create(file2, MediaType.get("application/text")))
+            .build();
+
+    final var request =
+        new Request.Builder()
+            .url("http://localhost:" + httpAddress.port() + "/v1/api/uploadReportError")
+            .post(body)
+            .build();
+
+    try (Response response = client.newCall(request).execute()) {
+      assertEquals(HttpResponseStatus.BAD_REQUEST.code(), response.code(), "response.code");
+      assertEquals(
+          "{\"errorCode\":400,\"errorMessage\":\"Too many file-upload parts\"}",
           response.body().string(),
           "response.body");
     }
@@ -152,4 +200,16 @@ public class FileUploadTest {
       throw new RuntimeException(e);
     }
   }
+
+  private static Stream<UploadFailedArgs> uploadFailedSource() {
+    return Stream.of(
+        new UploadFailedArgs(1024 * 1024, 500, file -> "Upload report failed: " + file.getName()),
+        new UploadFailedArgs(
+            SIZE_OVER_LIMIT,
+            500,
+            file -> "java.io.IOException: Size exceed allowed maximum capacity"));
+  }
+
+  private record UploadFailedArgs(
+      long fileSize, int errorCode, Function<File, String> errorMessageFunc) {}
 }

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/files/FileUploadTest.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/files/FileUploadTest.java
@@ -39,7 +39,7 @@ import reactor.core.publisher.Mono;
 
 public class FileUploadTest {
 
-  private static final int MAX_SIZE = 10 * 1024 * 1024;
+  private static final int MAX_SIZE = 15 * 1024 * 1024;
   private static final int SIZE_OVER_LIMIT = MAX_SIZE << 1;
 
   private static Microservices gateway;


### PR DESCRIPTION
Fixed https://github.com/scalecube/scalecube-services/issues/929

**Changes:**

* Added config setting - `HttpGateway.formDecoderBuilder (Consumer<HttpServerFormDecoderProvider.Builder>)` to configure mutlipart uploads.
* Enhanced `io.scalecube.services.gateway.http.HttpGatewayAcceptor.handleFileUploadRequest()`
  * added limitation of single multipath file upload part. 
  * refactored code regarding validating max file size.
* Added few more ITs.