### PR TITLE
Per-invocation customization of the underlying transport (HTTP) while still using ServiceCall abstraction

### DIFF
--- a/services-api/src/main/java/io/scalecube/services/RequestContext.java
+++ b/services-api/src/main/java/io/scalecube/services/RequestContext.java
@@ -9,8 +9,6 @@ import static io.scalecube.services.auth.Principal.NULL_PRINCIPAL;
 import io.scalecube.services.auth.Principal;
 import io.scalecube.services.exceptions.ForbiddenException;
 import io.scalecube.services.methods.MethodInfo;
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -228,8 +226,8 @@ public class RequestContext implements Context {
    *
    * @return path parameters, or {@code null} if not set
    */
-  public Map<String, String> pathParams() {
-    return source.getOrDefault(PATH_PARAMS_KEY, Collections.emptyMap());
+  public TypedParameters pathParams() {
+    return new TypedParameters(source.getOrDefault(PATH_PARAMS_KEY, Collections.emptyMap()));
   }
 
   /**
@@ -239,54 +237,6 @@ public class RequestContext implements Context {
    */
   public RequestContext pathParams(Map<String, String> pathParams) {
     return put(PATH_PARAMS_KEY, pathParams);
-  }
-
-  /**
-   * Returns specific path parameter by name.
-   *
-   * @param name name of the path parameter
-   * @return path parameter value, or {@code null} if not found
-   */
-  public String pathParam(String name) {
-    return pathParams().get(name);
-  }
-
-  /**
-   * Returns specific path parameter by name, and converts it to the specified type.
-   *
-   * @param name name of the path parameter
-   * @param type expected type of the path parameter
-   * @param <T> type parameter
-   * @return converted path parameter, or {@code null} if not found
-   */
-  public <T> T pathParam(String name, Class<T> type) {
-    final var s = pathParam(name);
-    if (s == null) {
-      return null;
-    }
-
-    if (type == String.class) {
-      //noinspection unchecked
-      return (T) s;
-    }
-    if (type == Integer.class) {
-      //noinspection unchecked
-      return (T) Integer.valueOf(s);
-    }
-    if (type == Long.class) {
-      //noinspection unchecked
-      return (T) Long.valueOf(s);
-    }
-    if (type == BigDecimal.class) {
-      //noinspection unchecked
-      return (T) new BigDecimal(s);
-    }
-    if (type == BigInteger.class) {
-      //noinspection unchecked
-      return (T) new BigInteger(s);
-    }
-
-    throw new IllegalArgumentException("Unsupported pathParam type: " + type);
   }
 
   /**
@@ -366,7 +316,7 @@ public class RequestContext implements Context {
         .add("principal=" + principal())
         .add("methodInfo=" + methodInfo())
         .add("headers=" + mask(headers()))
-        .add("pathParams=" + mask(pathParams()))
+        .add("pathParams=" + source.getOrDefault(PATH_PARAMS_KEY, Collections.emptyMap()))
         .add("sourceKeys=" + source.stream().map(Entry::getKey).toList())
         .toString();
   }

--- a/services-api/src/main/java/io/scalecube/services/RequestContext.java
+++ b/services-api/src/main/java/io/scalecube/services/RequestContext.java
@@ -34,7 +34,7 @@ public class RequestContext implements Context {
   private static final Object REQUEST_KEY = new Object();
   private static final Object PRINCIPAL_KEY = new Object();
   private static final Object METHOD_INFO_KEY = new Object();
-  private static final Object PATH_VARS_KEY = new Object();
+  private static final Object PATH_PARAMS_KEY = new Object();
 
   private final Context source;
 
@@ -224,43 +224,43 @@ public class RequestContext implements Context {
   }
 
   /**
-   * Returns path variables associated with the request.
+   * Returns path parameters associated with the request.
    *
-   * @return path variables, or {@code null} if not set
+   * @return path parameters, or {@code null} if not set
    */
-  public Map<String, String> pathVars() {
-    return source.getOrDefault(PATH_VARS_KEY, Collections.emptyMap());
+  public Map<String, String> pathParams() {
+    return source.getOrDefault(PATH_PARAMS_KEY, Collections.emptyMap());
   }
 
   /**
-   * Puts path variables associated with the request.
+   * Puts path parameters associated with the request.
    *
-   * @return path variables, or {@code null} if not set
+   * @return path parameters, or {@code null} if not set
    */
-  public RequestContext pathVars(Map<String, String> pathVars) {
-    return put(PATH_VARS_KEY, pathVars);
+  public RequestContext pathParams(Map<String, String> pathParams) {
+    return put(PATH_PARAMS_KEY, pathParams);
   }
 
   /**
-   * Returns specific path variable by name.
+   * Returns specific path parameter by name.
    *
-   * @param name name of the path variable
-   * @return path variable value, or {@code null} if not found
+   * @param name name of the path parameter
+   * @return path parameter value, or {@code null} if not found
    */
-  public String pathVar(String name) {
-    return pathVars().get(name);
+  public String pathParam(String name) {
+    return pathParams().get(name);
   }
 
   /**
-   * Returns specific path variable by name, and converts it to the specified type.
+   * Returns specific path parameter by name, and converts it to the specified type.
    *
-   * @param name name of the path variable
-   * @param type expected type of the variable
+   * @param name name of the path parameter
+   * @param type expected type of the path parameter
    * @param <T> type parameter
-   * @return converted path variable, or {@code null} if not found
+   * @return converted path parameter, or {@code null} if not found
    */
-  public <T> T pathVar(String name, Class<T> type) {
-    final var s = pathVar(name);
+  public <T> T pathParam(String name, Class<T> type) {
+    final var s = pathParam(name);
     if (s == null) {
       return null;
     }
@@ -286,7 +286,7 @@ public class RequestContext implements Context {
       return (T) new BigInteger(s);
     }
 
-    throw new IllegalArgumentException("Unsupported pathVar type: " + type);
+    throw new IllegalArgumentException("Unsupported pathParam type: " + type);
   }
 
   /**
@@ -366,7 +366,7 @@ public class RequestContext implements Context {
         .add("principal=" + principal())
         .add("methodInfo=" + methodInfo())
         .add("headers=" + mask(headers()))
-        .add("pathVars=" + mask(pathVars()))
+        .add("pathParams=" + mask(pathParams()))
         .add("sourceKeys=" + source.stream().map(Entry::getKey).toList())
         .toString();
   }

--- a/services-api/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services-api/src/main/java/io/scalecube/services/ServiceCall.java
@@ -425,13 +425,17 @@ public class ServiceCall implements AutoCloseable {
   private static Function<Flux<ServiceMessage>, Flux<Object>> asFlux(
       boolean isReturnTypeServiceMessage) {
     return flux ->
-        isReturnTypeServiceMessage ? flux.cast(Object.class) : flux.map(ServiceMessage::data);
+        isReturnTypeServiceMessage
+            ? flux.cast(Object.class)
+            : flux.mapNotNull(ServiceMessage::data);
   }
 
   private static Function<Mono<ServiceMessage>, Mono<Object>> asMono(
       boolean isReturnTypeServiceMessage) {
     return mono ->
-        isReturnTypeServiceMessage ? mono.cast(Object.class) : mono.map(ServiceMessage::data);
+        isReturnTypeServiceMessage
+            ? mono.cast(Object.class)
+            : mono.mapNotNull(ServiceMessage::data);
   }
 
   private ServiceMessage throwIfError(ServiceMessage message) {

--- a/services-api/src/main/java/io/scalecube/services/TypedParameters.java
+++ b/services-api/src/main/java/io/scalecube/services/TypedParameters.java
@@ -14,35 +14,35 @@ public class TypedParameters {
     this.params = new LinkedHashMap<>(params != null ? params : Map.of());
   }
 
-  public Integer intValue(String name) {
+  public Integer getInt(String name) {
     return get(name, Integer::parseInt);
   }
 
-  public Long longValue(String name) {
+  public Long getLong(String name) {
     return get(name, Long::parseLong);
   }
 
-  public BigInteger bigInteger(String name) {
+  public BigInteger getBigInteger(String name) {
     return get(name, BigInteger::new);
   }
 
-  public Double doubleValue(String name) {
+  public Double getDouble(String name) {
     return get(name, Double::parseDouble);
   }
 
-  public BigDecimal bigDecimal(String name) {
+  public BigDecimal getBigDecimal(String name) {
     return get(name, BigDecimal::new);
   }
 
-  public <T extends Enum<T>> T enumValue(String name, Function<String, T> enumFunc) {
+  public <T extends Enum<T>> T getEnum(String name, Function<String, T> enumFunc) {
     return get(name, enumFunc);
   }
 
-  public Boolean booleanValue(String name) {
+  public Boolean getBoolean(String name) {
     return get(name, Boolean::parseBoolean);
   }
 
-  public String stringValue(String name) {
+  public String getString(String name) {
     return get(name, s -> s);
   }
 

--- a/services-api/src/main/java/io/scalecube/services/TypedParameters.java
+++ b/services-api/src/main/java/io/scalecube/services/TypedParameters.java
@@ -1,0 +1,53 @@
+package io.scalecube.services;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public class TypedParameters {
+
+  private final Map<String, String> params;
+
+  public TypedParameters(Map<String, String> params) {
+    this.params = new LinkedHashMap<>(params != null ? params : Map.of());
+  }
+
+  public Integer intValue(String name) {
+    return get(name, Integer::parseInt);
+  }
+
+  public Long longValue(String name) {
+    return get(name, Long::parseLong);
+  }
+
+  public BigInteger bigInteger(String name) {
+    return get(name, BigInteger::new);
+  }
+
+  public Double doubleValue(String name) {
+    return get(name, Double::parseDouble);
+  }
+
+  public BigDecimal bigDecimal(String name) {
+    return get(name, BigDecimal::new);
+  }
+
+  public <T extends Enum<T>> T enumValue(String name, Function<String, T> enumFunc) {
+    return get(name, enumFunc);
+  }
+
+  public Boolean booleanValue(String name) {
+    return get(name, Boolean::parseBoolean);
+  }
+
+  public String stringValue(String name) {
+    return get(name, s -> s);
+  }
+
+  public <T> T get(String name, Function<String, T> converter) {
+    final var s = params.get(name);
+    return s != null ? converter.apply(s) : null;
+  }
+}

--- a/services-api/src/main/java/io/scalecube/services/api/DynamicQualifier.java
+++ b/services-api/src/main/java/io/scalecube/services/api/DynamicQualifier.java
@@ -98,7 +98,7 @@ public final class DynamicQualifier {
   }
 
   /**
-   * Size of qualifier. This is a number of {@code /} symbols.
+   * Size of qualifier. A number of {@code /} symbols.
    *
    * @return result
    */
@@ -136,10 +136,10 @@ public final class DynamicQualifier {
     return map;
   }
 
-  private static int sizeOf(String value) {
+  private static int sizeOf(String path) {
     int count = 0;
-    for (int i = 0, length = value.length(); i < length; i++) {
-      if (value.charAt(i) == '/') {
+    for (int i = 0, length = path.length(); i < length; i++) {
+      if (path.charAt(i) == '/') {
         count++;
       }
     }

--- a/services-api/src/main/java/io/scalecube/services/api/DynamicQualifier.java
+++ b/services-api/src/main/java/io/scalecube/services/api/DynamicQualifier.java
@@ -89,9 +89,9 @@ public final class DynamicQualifier {
   }
 
   /**
-   * Returns path variable names.
+   * Returns path parameter names.
    *
-   * @return path variable names
+   * @return path parameter names
    */
   public List<String> pathParams() {
     return pathParams;
@@ -107,10 +107,10 @@ public final class DynamicQualifier {
   }
 
   /**
-   * Matches input qualifier against this dynamic qualifier.
+   * Matches given qualifier string with this {@link DynamicQualifier}.
    *
-   * @param qualifier qualifier
-   * @return matched path variables key-value map, or null if no matching occurred
+   * @param qualifier qualifier string
+   * @return matched path parameters key-value map, or null if no matching occurred
    */
   public Map<String, String> matchQualifier(String qualifier) {
     final var path = qualifier.split("\\?")[0];

--- a/services-api/src/main/java/io/scalecube/services/api/DynamicQualifier.java
+++ b/services-api/src/main/java/io/scalecube/services/api/DynamicQualifier.java
@@ -25,7 +25,7 @@ public final class DynamicQualifier {
 
   private final String qualifier;
   private final Pattern pattern;
-  private final List<String> pathVariables;
+  private final List<String> pathParams;
   private final int size;
 
   private DynamicQualifier(String qualifier) {
@@ -34,9 +34,9 @@ public final class DynamicQualifier {
 
     for (var s : qualifier.split("/")) {
       if (s.startsWith(":")) {
-        final var pathVar = s.substring(1);
-        builder.append("(?<").append(pathVar).append(">.+)");
-        list.add(pathVar);
+        final var param = s.substring(1);
+        builder.append("(?<").append(param).append(">.+)");
+        list.add(param);
       } else {
         builder.append(s);
       }
@@ -46,7 +46,7 @@ public final class DynamicQualifier {
 
     this.qualifier = qualifier;
     this.pattern = Pattern.compile(builder.toString());
-    this.pathVariables = Collections.unmodifiableList(list);
+    this.pathParams = Collections.unmodifiableList(list);
     this.size = sizeOf(qualifier);
   }
 
@@ -93,8 +93,8 @@ public final class DynamicQualifier {
    *
    * @return path variable names
    */
-  public List<String> pathVariables() {
-    return pathVariables;
+  public List<String> pathParams() {
+    return pathParams;
   }
 
   /**
@@ -125,12 +125,12 @@ public final class DynamicQualifier {
     }
 
     final var map = new LinkedHashMap<String, String>();
-    for (var pathVar : pathVariables) {
-      final var value = matcher.group(pathVar);
+    for (var param : pathParams) {
+      final var value = matcher.group(param);
       if (value == null || value.isEmpty()) {
-        throw new IllegalArgumentException("Wrong path variable: " + pathVar);
+        throw new IllegalArgumentException("Wrong path param: " + param);
       }
-      map.put(pathVar, value);
+      map.put(param, value);
     }
 
     return map;
@@ -167,7 +167,7 @@ public final class DynamicQualifier {
     return new StringJoiner(", ", DynamicQualifier.class.getSimpleName() + "[", "]")
         .add("qualifier='" + qualifier + "'")
         .add("pattern=" + pattern)
-        .add("pathVariables=" + pathVariables)
+        .add("pathParams=" + pathParams)
         .add("size=" + size)
         .toString();
   }

--- a/services-api/src/main/java/io/scalecube/services/api/DynamicQualifier.java
+++ b/services-api/src/main/java/io/scalecube/services/api/DynamicQualifier.java
@@ -113,11 +113,13 @@ public final class DynamicQualifier {
    * @return matched path variables key-value map, or null if no matching occurred
    */
   public Map<String, String> matchQualifier(String qualifier) {
-    if (size != sizeOf(qualifier)) {
+    final var path = qualifier.split("\\?")[0];
+
+    if (size != sizeOf(path)) {
       return null;
     }
 
-    final var matcher = pattern.matcher(qualifier);
+    final var matcher = pattern.matcher(path);
     if (!matcher.matches()) {
       return null;
     }

--- a/services-api/src/main/java/io/scalecube/services/methods/ServiceMethodInvoker.java
+++ b/services-api/src/main/java/io/scalecube/services/methods/ServiceMethodInvoker.java
@@ -255,15 +255,15 @@ public class ServiceMethodInvoker {
       RequestContext context, Object request, Principal principal) {
     final var dynamicQualifier = methodInfo.dynamicQualifier();
 
-    Map<String, String> pathVars = null;
+    Map<String, String> pathParams = null;
     if (dynamicQualifier != null) {
-      pathVars = dynamicQualifier.matchQualifier(context.requestQualifier());
+      pathParams = dynamicQualifier.matchQualifier(context.requestQualifier());
     }
 
     return new RequestContext(context)
         .request(request)
         .principal(principal)
-        .pathVars(pathVars)
+        .pathParams(pathParams)
         .methodInfo(methodInfo);
   }
 

--- a/services-api/src/main/java/io/scalecube/services/routing/StaticAddressRouter.java
+++ b/services-api/src/main/java/io/scalecube/services/routing/StaticAddressRouter.java
@@ -81,7 +81,7 @@ public class StaticAddressRouter implements Router {
     /**
      * Setter for whether to apply behavior of {@link CredentialsSupplier}, or not. If it is known
      * upfront that destination service is secured, then set this flag to {@code true}, in such case
-     * {@link CredentialsSupplier#credentials(String)} will be invoked.
+     * {@link CredentialsSupplier#credentials(String, String)}} will be invoked.
      *
      * @param secured secured flag
      * @return this
@@ -93,7 +93,7 @@ public class StaticAddressRouter implements Router {
 
     /**
      * Setter for {@code serviceRole} property, will be used in the invocation of {@link
-     * CredentialsSupplier#credentials(String)}.
+     * CredentialsSupplier#credentials(String, String)}.
      *
      * @param serviceRole serviceRole
      * @return this
@@ -105,7 +105,7 @@ public class StaticAddressRouter implements Router {
 
     /**
      * Setter for {@code serviceName} property, will be used in the invocation of {@link
-     * CredentialsSupplier#credentials(String)}.
+     * CredentialsSupplier#credentials(String, String)}.
      *
      * @param serviceName serviceName
      * @return this

--- a/services-api/src/test/java/io/scalecube/services/api/DynamicQualifierTest.java
+++ b/services-api/src/test/java/io/scalecube/services/api/DynamicQualifierTest.java
@@ -82,7 +82,7 @@ class DynamicQualifierTest {
   }
 
   @Test
-  void testMatchSinglePathVariable() {
+  void testMatchSinglePathParam() {
     final var userName = UUID.randomUUID().toString();
     final var qualifier = DynamicQualifier.from("v1/this.is.namespace/foo/bar/:userName");
     final var map = qualifier.matchQualifier("v1/this.is.namespace/foo/bar/" + userName);
@@ -92,7 +92,7 @@ class DynamicQualifierTest {
   }
 
   @Test
-  void testMatchMultiplePathVariables() {
+  void testMatchMultiplePathParams() {
     final var qualifier = DynamicQualifier.from("v1/this.is.namespace/foo/:foo/bar/:bar/baz/:baz");
     final var map = qualifier.matchQualifier("v1/this.is.namespace/foo/123/bar/456/baz/678");
     assertNotNull(map);
@@ -113,7 +113,7 @@ class DynamicQualifierTest {
   }
 
   @Test
-  void testMatchMultipleVariablesWithQueryStringIgnored() {
+  void testMatchMultipleWithQueryStringIgnored() {
     final var qualifier = DynamicQualifier.from("v1/this.is.namespace/foo/:foo/bar/:bar");
 
     final var map = qualifier.matchQualifier("v1/this.is.namespace/foo/123/bar/456?debug=true");

--- a/services-api/src/test/java/io/scalecube/services/api/DynamicQualifierTest.java
+++ b/services-api/src/test/java/io/scalecube/services/api/DynamicQualifierTest.java
@@ -101,4 +101,25 @@ class DynamicQualifierTest {
     assertEquals("456", map.get("bar"));
     assertEquals("678", map.get("baz"));
   }
+
+  @Test
+  void testMatchWithQueryString() {
+    final var qualifier = DynamicQualifier.from("v1/this.is.namespace/foo/:foo/bar/:bar");
+    final var map = qualifier.matchQualifier("v1/this.is.namespace/foo/123/bar/456?x=1&y=2");
+
+    assertNotNull(map);
+    assertEquals("123", map.get("foo"));
+    assertEquals("456", map.get("bar"));
+  }
+
+  @Test
+  void testMatchMultipleVariablesWithQueryStringIgnored() {
+    final var qualifier = DynamicQualifier.from("v1/this.is.namespace/foo/:foo/bar/:bar");
+
+    final var map = qualifier.matchQualifier("v1/this.is.namespace/foo/123/bar/456?debug=true");
+
+    assertNotNull(map);
+    assertEquals("123", map.get("foo"));
+    assertEquals("456", map.get("bar"));
+  }
 }

--- a/services-api/src/test/java/io/scalecube/services/methods/StubServiceImpl.java
+++ b/services-api/src/test/java/io/scalecube/services/methods/StubServiceImpl.java
@@ -51,9 +51,10 @@ public class StubServiceImpl implements StubService {
             context -> {
               assertNotNull(context.headers(), "headers");
               assertNotNull(context.principal(), "principal");
-              assertNotNull(context.pathParams(), "pathParams");
-              assertNotNull(context.pathParam("foo"), "pathParam[foo]");
-              assertNotNull(context.pathParam("bar"), "pathParam[bar]");
+              final var pathParams = context.pathParams();
+              assertNotNull(pathParams, "pathParams");
+              assertNotNull(pathParams.stringValue("foo"), "pathParam[foo]");
+              assertNotNull(pathParams.stringValue("bar"), "pathParam[bar]");
             })
         .then();
   }

--- a/services-api/src/test/java/io/scalecube/services/methods/StubServiceImpl.java
+++ b/services-api/src/test/java/io/scalecube/services/methods/StubServiceImpl.java
@@ -53,8 +53,8 @@ public class StubServiceImpl implements StubService {
               assertNotNull(context.principal(), "principal");
               final var pathParams = context.pathParams();
               assertNotNull(pathParams, "pathParams");
-              assertNotNull(pathParams.stringValue("foo"), "pathParam[foo]");
-              assertNotNull(pathParams.stringValue("bar"), "pathParam[bar]");
+              assertNotNull(pathParams.getString("foo"), "pathParam[foo]");
+              assertNotNull(pathParams.getString("bar"), "pathParam[bar]");
             })
         .then();
   }

--- a/services-api/src/test/java/io/scalecube/services/methods/StubServiceImpl.java
+++ b/services-api/src/test/java/io/scalecube/services/methods/StubServiceImpl.java
@@ -51,9 +51,9 @@ public class StubServiceImpl implements StubService {
             context -> {
               assertNotNull(context.headers(), "headers");
               assertNotNull(context.principal(), "principal");
-              assertNotNull(context.pathVars(), "pathVars");
-              assertNotNull(context.pathVar("foo"), "pathVar[foo]");
-              assertNotNull(context.pathVar("bar"), "pathVar[bar]");
+              assertNotNull(context.pathParams(), "pathParams");
+              assertNotNull(context.pathParam("foo"), "pathParam[foo]");
+              assertNotNull(context.pathParam("bar"), "pathParam[bar]");
             })
         .then();
   }

--- a/services-examples/src/main/java/io/scalecube/services/examples/GreetingServiceImpl.java
+++ b/services-examples/src/main/java/io/scalecube/services/examples/GreetingServiceImpl.java
@@ -107,6 +107,6 @@ public class GreetingServiceImpl implements GreetingService {
   @Override
   public Mono<String> helloDynamicQualifier(Long value) {
     return RequestContext.deferContextual()
-        .map(context -> context.pathParams().stringValue("someVar") + "@" + value);
+        .map(context -> context.pathParams().getString("someVar") + "@" + value);
   }
 }

--- a/services-examples/src/main/java/io/scalecube/services/examples/GreetingServiceImpl.java
+++ b/services-examples/src/main/java/io/scalecube/services/examples/GreetingServiceImpl.java
@@ -107,6 +107,6 @@ public class GreetingServiceImpl implements GreetingService {
   @Override
   public Mono<String> helloDynamicQualifier(Long value) {
     return RequestContext.deferContextual()
-        .map(context -> context.pathParam("someVar") + "@" + value);
+        .map(context -> context.pathParams().stringValue("someVar") + "@" + value);
   }
 }

--- a/services-examples/src/main/java/io/scalecube/services/examples/GreetingServiceImpl.java
+++ b/services-examples/src/main/java/io/scalecube/services/examples/GreetingServiceImpl.java
@@ -107,6 +107,6 @@ public class GreetingServiceImpl implements GreetingService {
   @Override
   public Mono<String> helloDynamicQualifier(Long value) {
     return RequestContext.deferContextual()
-        .map(context -> context.pathVar("someVar") + "@" + value);
+        .map(context -> context.pathParam("someVar") + "@" + value);
   }
 }

--- a/services-gateway/src/main/java/io/scalecube/services/gateway/client/http/HttpGatewayClientTransport.java
+++ b/services-gateway/src/main/java/io/scalecube/services/gateway/client/http/HttpGatewayClientTransport.java
@@ -148,8 +148,9 @@ public final class HttpGatewayClientTransport implements ClientChannel, ClientTr
             .qualifier(httpResponse.uri())
             .data(data != Unpooled.EMPTY_BUFFER ? data : null);
 
-    if (isError(httpResponse.status())) {
-      builder.header(ServiceMessage.HEADER_ERROR_TYPE, httpResponse.status().code());
+    final var status = httpResponse.status();
+    if (isError(status)) {
+      builder.header(ServiceMessage.HEADER_ERROR_TYPE, status.code());
     }
 
     // Populate HTTP response headers

--- a/services-gateway/src/main/java/io/scalecube/services/gateway/http/HttpGatewayAcceptor.java
+++ b/services-gateway/src/main/java/io/scalecube/services/gateway/http/HttpGatewayAcceptor.java
@@ -214,10 +214,6 @@ public class HttpGatewayAcceptor
       HttpServerRequest httpRequest, Consumer<Builder> consumer) {
     final var builder = ServiceMessage.builder();
 
-    // Copy HTTP method
-
-    builder.header("http.method", httpRequest.method().name());
-
     // Copy HTTP headers to service message
 
     for (var httpHeader : httpRequest.requestHeaders()) {
@@ -227,6 +223,7 @@ public class HttpGatewayAcceptor
     // Add HTTP method to service message (used by REST services)
 
     builder
+        .header("http.method", httpRequest.method().name())
         .header(HEADER_REQUEST_METHOD, httpRequest.method().name())
         .qualifier(httpRequest.uri().substring(1));
     if (consumer != null) {

--- a/services-gateway/src/main/java/io/scalecube/services/gateway/http/HttpGatewayAcceptor.java
+++ b/services-gateway/src/main/java/io/scalecube/services/gateway/http/HttpGatewayAcceptor.java
@@ -214,13 +214,17 @@ public class HttpGatewayAcceptor
       HttpServerRequest httpRequest, Consumer<Builder> consumer) {
     final var builder = ServiceMessage.builder();
 
-    // Copy http headers to service message
+    // Copy HTTP method
+
+    builder.header("http.method", httpRequest.method().name());
+
+    // Copy HTTP headers to service message
 
     for (var httpHeader : httpRequest.requestHeaders()) {
-      builder.header(httpHeader.getKey(), httpHeader.getValue());
+      builder.header("http.header." + httpHeader.getKey(), httpHeader.getValue());
     }
 
-    // Add http method to service message (used by REST services)
+    // Add HTTP method to service message (used by REST services)
 
     builder
         .header(HEADER_REQUEST_METHOD, httpRequest.method().name())

--- a/services-gateway/src/main/java/io/scalecube/services/gateway/http/HttpGatewayAcceptor.java
+++ b/services-gateway/src/main/java/io/scalecube/services/gateway/http/HttpGatewayAcceptor.java
@@ -255,7 +255,8 @@ public class HttpGatewayAcceptor
             ? encodeData(response.data(), response.dataFormatOrDefault())
             : ((ByteBuf) response.data());
 
-    // send with publisher (defer buffer cleanup to netty)
+    // Send with publisher (defer buffer cleanup to netty)
+
     return httpResponse.status(status).send(Mono.just(content)).then();
   }
 
@@ -269,7 +270,8 @@ public class HttpGatewayAcceptor
             ? ((ByteBuf) response.data())
             : encodeData(response.data(), response.dataFormatOrDefault());
 
-    // send with publisher (defer buffer cleanup to netty)
+    // Send with publisher (defer buffer cleanup to netty)
+
     return httpResponse.status(OK).send(Mono.just(content)).then();
   }
 

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/files/ReportServiceImpl.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/files/ReportServiceImpl.java
@@ -123,7 +123,7 @@ public class ReportServiceImpl implements ReportService {
         .flatMapMany(
             context -> {
               final var pathParams = context.pathParams();
-              final var fileSize = pathParams.longValue("fileSize");
+              final var fileSize = pathParams.getLong("fileSize");
               final var headers = context.headers();
               final File file;
               try {

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/files/ReportServiceImpl.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/files/ReportServiceImpl.java
@@ -122,7 +122,8 @@ public class ReportServiceImpl implements ReportService {
     return RequestContext.deferContextual()
         .flatMapMany(
             context -> {
-              final var fileSize = context.pathParam("fileSize", Long.class);
+              final var pathParams = context.pathParams();
+              final var fileSize = pathParams.longValue("fileSize");
               final var headers = context.headers();
               final File file;
               try {

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/files/ReportServiceImpl.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/files/ReportServiceImpl.java
@@ -122,7 +122,7 @@ public class ReportServiceImpl implements ReportService {
     return RequestContext.deferContextual()
         .flatMapMany(
             context -> {
-              final var fileSize = context.pathVar("fileSize", Long.class);
+              final var fileSize = context.pathParam("fileSize", Long.class);
               final var headers = context.headers();
               final File file;
               try {

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestGatewayTest.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestGatewayTest.java
@@ -1,50 +1,51 @@
 package io.scalecube.services.gateway.rest;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.netty.handler.codec.http.HttpResponseStatus;
+import io.scalecube.services.Address;
 import io.scalecube.services.Microservices;
 import io.scalecube.services.Microservices.Context;
 import io.scalecube.services.ServiceCall;
 import io.scalecube.services.ServiceInfo;
-import io.scalecube.services.api.ErrorData;
+import io.scalecube.services.api.ServiceMessage;
 import io.scalecube.services.discovery.ScalecubeServiceDiscovery;
 import io.scalecube.services.examples.GreetingServiceImpl;
 import io.scalecube.services.exceptions.ServiceUnavailableException;
+import io.scalecube.services.gateway.client.http.HttpGatewayClientTransport;
 import io.scalecube.services.gateway.client.websocket.WebsocketGatewayClientTransport;
 import io.scalecube.services.gateway.http.HttpGateway;
 import io.scalecube.services.gateway.websocket.WebsocketGateway;
 import io.scalecube.services.routing.StaticAddressRouter;
 import io.scalecube.services.transport.rsocket.RSocketServiceTransport;
 import io.scalecube.transport.netty.websocket.WebsocketTransportFactory;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpRequest.BodyPublishers;
-import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import reactor.test.StepVerifier;
 
 public class RestGatewayTest {
 
   private static Microservices gateway;
   private static Microservices microservices;
-  private static HttpClient httpClient;
 
-  private final ObjectMapper objectMapper = objectMapper();
-  private static String httpGatewayAddress;
+  private static final ObjectMapper objectMapper = objectMapper();
+  private static Address gatewayAddress;
+  private static StaticAddressRouter router;
 
   @BeforeAll
   static void beforeAll() {
@@ -61,7 +62,8 @@ public class RestGatewayTest {
                 .gateway(() -> HttpGateway.builder().id("HTTP").build())
                 .gateway(() -> WebsocketGateway.builder().id("WS").build()));
 
-    httpGatewayAddress = "http://localhost:" + gateway.gateway("HTTP").address().port();
+    gatewayAddress = Address.from("localhost:" + gateway.gateway("HTTP").address().port());
+    router = StaticAddressRouter.forService(gatewayAddress, "app-service").build();
 
     microservices =
         Microservices.start(
@@ -78,8 +80,6 @@ public class RestGatewayTest {
                 .services(new GreetingServiceImpl())
                 .services(ServiceInfo.fromServiceInstance(new RestServiceImpl()).build())
                 .services(ServiceInfo.fromServiceInstance(new RoutingServiceImpl()).build()));
-
-    httpClient = HttpClient.newHttpClient();
   }
 
   @AfterAll
@@ -98,201 +98,277 @@ public class RestGatewayTest {
     mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
     mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
     mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-    mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
-    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    mapper.setVisibility(PropertyAccessor.ALL, Visibility.ANY);
+    mapper.setSerializationInclusion(Include.NON_NULL);
     mapper.configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
     mapper.registerModule(new JavaTimeModule());
     return mapper;
   }
 
   @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
   class GatewayTests {
 
-    @Test
-    void testOptions() throws Exception {
-      final var fooParam = "options" + System.currentTimeMillis();
-      final var httpRequest =
-          HttpRequest.newBuilder(
-                  new URI(httpGatewayAddress + "/v1/restService/options/" + fooParam))
-              .method("OPTIONS", BodyPublishers.noBody())
-              .build();
-      final var httpResponse = httpClient.send(httpRequest, BodyHandlers.ofString());
-      assertEquals(HttpResponseStatus.OK.code(), httpResponse.statusCode(), "statusCode");
-      assertEquals(
-          fooParam,
-          objectMapper.readValue(httpResponse.body(), SomeResponse.class).name(),
-          "response");
+    private ServiceCall serviceCall;
+
+    @BeforeAll
+    void beforeAll() {
+      serviceCall =
+          new ServiceCall()
+              .transport(HttpGatewayClientTransport.builder().address(gatewayAddress).build())
+              .router(router);
+    }
+
+    @AfterAll
+    void afterAll() {
+      if (serviceCall != null) {
+        serviceCall.close();
+      }
     }
 
     @Test
-    void testGet() throws Exception {
-      final var fooParam = "get" + System.currentTimeMillis();
-      final var httpRequest =
-          HttpRequest.newBuilder(new URI(httpGatewayAddress + "/v1/restService/get/" + fooParam))
-              .method("GET", BodyPublishers.noBody())
-              .build();
-      final var httpResponse = httpClient.send(httpRequest, BodyHandlers.ofString());
-      assertEquals(HttpResponseStatus.OK.code(), httpResponse.statusCode(), "statusCode");
-      assertEquals(
-          fooParam,
-          objectMapper.readValue(httpResponse.body(), SomeResponse.class).name(),
-          "response");
+    void testOptions() {
+      final var param = "options" + System.currentTimeMillis();
+      StepVerifier.create(
+              serviceCall.requestOne(
+                  ServiceMessage.builder()
+                      .header("http.method", "OPTIONS")
+                      .qualifier("v1/restService/options/" + param)
+                      .build(),
+                  SomeResponse.class))
+          .assertNext(
+              message -> {
+                final var someResponse = message.<SomeResponse>data();
+                assertNotNull(someResponse, "data");
+                assertEquals(param, someResponse.name(), "someResponse.name");
+              })
+          .verifyComplete();
     }
 
     @Test
-    void testHead() throws Exception {
-      final var fooParam = "head" + System.currentTimeMillis();
-      final var httpRequest =
-          HttpRequest.newBuilder(new URI(httpGatewayAddress + "/v1/restService/head/" + fooParam))
-              .method("HEAD", BodyPublishers.noBody())
-              .build();
-      final var httpResponse = httpClient.send(httpRequest, BodyHandlers.ofString());
-      assertEquals(HttpResponseStatus.OK.code(), httpResponse.statusCode(), "statusCode");
-      assertEquals("", httpResponse.body(), "response");
+    void testGet() {
+      final var param = "get" + System.currentTimeMillis();
+      StepVerifier.create(
+              serviceCall.requestOne(
+                  ServiceMessage.builder()
+                      .header("http.method", "GET")
+                      .qualifier("v1/restService/get/" + param)
+                      .build(),
+                  SomeResponse.class))
+          .assertNext(
+              message -> {
+                final var someResponse = message.<SomeResponse>data();
+                assertNotNull(someResponse, "data");
+                assertEquals(param, someResponse.name(), "someResponse.name");
+              })
+          .verifyComplete();
     }
 
     @Test
-    void testPost() throws Exception {
+    void testHead() {
+      final var param = "head" + System.currentTimeMillis();
+      StepVerifier.create(
+              serviceCall.requestOne(
+                  ServiceMessage.builder()
+                      .header("http.method", "HEAD")
+                      .qualifier("v1/restService/head/" + param)
+                      .build(),
+                  SomeResponse.class))
+          .assertNext(
+              message -> {
+                final var someResponse = message.<SomeResponse>data();
+                assertNotNull(someResponse, "data");
+                assertEquals(param, someResponse.name(), "someResponse.name");
+              })
+          .verifyComplete();
+    }
+
+    @Test
+    void testPost() {
       final var name = "name" + System.currentTimeMillis();
-      final var fooParam = "post" + System.currentTimeMillis();
-      final var httpRequest =
-          HttpRequest.newBuilder(new URI(httpGatewayAddress + "/v1/restService/post/" + fooParam))
-              .method(
-                  "POST",
-                  BodyPublishers.ofString(
-                      objectMapper.writeValueAsString(new SomeRequest().name(name))))
-              .build();
-      final var httpResponse = httpClient.send(httpRequest, BodyHandlers.ofString());
-      assertEquals(HttpResponseStatus.OK.code(), httpResponse.statusCode(), "statusCode");
-      assertEquals(
-          name, objectMapper.readValue(httpResponse.body(), SomeResponse.class).name(), "response");
+      final var param = "post" + System.currentTimeMillis();
+      StepVerifier.create(
+              serviceCall.requestOne(
+                  ServiceMessage.builder()
+                      .header("http.method", "POST")
+                      .qualifier("v1/restService/post/" + param)
+                      .data(new SomeRequest().name(name))
+                      .build(),
+                  SomeResponse.class))
+          .assertNext(
+              message -> {
+                final var someResponse = message.<SomeResponse>data();
+                assertNotNull(someResponse, "data");
+                assertEquals(name, someResponse.name(), "someResponse.name");
+              })
+          .verifyComplete();
     }
 
     @Test
-    void testPut() throws Exception {
+    void testPut() {
       final var name = "name" + System.currentTimeMillis();
-      final var fooParam = "put" + System.currentTimeMillis();
-      final var httpRequest =
-          HttpRequest.newBuilder(new URI(httpGatewayAddress + "/v1/restService/put/" + fooParam))
-              .method(
-                  "PUT",
-                  BodyPublishers.ofString(
-                      objectMapper.writeValueAsString(new SomeRequest().name(name))))
-              .build();
-      final var httpResponse = httpClient.send(httpRequest, BodyHandlers.ofString());
-      assertEquals(HttpResponseStatus.OK.code(), httpResponse.statusCode(), "statusCode");
-      assertEquals(
-          name, objectMapper.readValue(httpResponse.body(), SomeResponse.class).name(), "response");
+      final var param = "put" + System.currentTimeMillis();
+      StepVerifier.create(
+              serviceCall.requestOne(
+                  ServiceMessage.builder()
+                      .header("http.method", "PUT")
+                      .qualifier("v1/restService/put/" + param)
+                      .data(new SomeRequest().name(name))
+                      .build(),
+                  SomeResponse.class))
+          .assertNext(
+              message -> {
+                final var someResponse = message.<SomeResponse>data();
+                assertNotNull(someResponse, "data");
+                assertEquals(name, someResponse.name(), "someResponse.name");
+              })
+          .verifyComplete();
     }
 
     @Test
-    void testPatch() throws Exception {
+    void testPatch() {
       final var name = "name" + System.currentTimeMillis();
-      final var fooParam = "patch" + System.currentTimeMillis();
-      final var httpRequest =
-          HttpRequest.newBuilder(new URI(httpGatewayAddress + "/v1/restService/patch/" + fooParam))
-              .method(
-                  "PATCH",
-                  BodyPublishers.ofString(
-                      objectMapper.writeValueAsString(new SomeRequest().name(name))))
-              .build();
-      final var httpResponse = httpClient.send(httpRequest, BodyHandlers.ofString());
-      assertEquals(HttpResponseStatus.OK.code(), httpResponse.statusCode(), "statusCode");
-      assertEquals(
-          name, objectMapper.readValue(httpResponse.body(), SomeResponse.class).name(), "response");
+      final var param = "patch" + System.currentTimeMillis();
+      StepVerifier.create(
+              serviceCall.requestOne(
+                  ServiceMessage.builder()
+                      .header("http.method", "PATCH")
+                      .qualifier("v1/restService/patch/" + param)
+                      .data(new SomeRequest().name(name))
+                      .build(),
+                  SomeResponse.class))
+          .assertNext(
+              message -> {
+                final var someResponse = message.<SomeResponse>data();
+                assertNotNull(someResponse, "data");
+                assertEquals(name, someResponse.name(), "someResponse.name");
+              })
+          .verifyComplete();
     }
 
     @Test
-    void testDelete() throws Exception {
+    void testDelete() {
       final var name = "name" + System.currentTimeMillis();
-      final var fooParam = "delete" + System.currentTimeMillis();
-      final var httpRequest =
-          HttpRequest.newBuilder(new URI(httpGatewayAddress + "/v1/restService/delete/" + fooParam))
-              .method(
-                  "DELETE",
-                  BodyPublishers.ofString(
-                      objectMapper.writeValueAsString(new SomeRequest().name(name))))
-              .build();
-      final var httpResponse = httpClient.send(httpRequest, BodyHandlers.ofString());
-      assertEquals(HttpResponseStatus.OK.code(), httpResponse.statusCode(), "statusCode");
-      assertEquals(
-          name, objectMapper.readValue(httpResponse.body(), SomeResponse.class).name(), "response");
+      final var param = "delete" + System.currentTimeMillis();
+      StepVerifier.create(
+              serviceCall.requestOne(
+                  ServiceMessage.builder()
+                      .header("http.method", "DELETE")
+                      .qualifier("v1/restService/delete/" + param)
+                      .data(new SomeRequest().name(name))
+                      .build(),
+                  SomeResponse.class))
+          .assertNext(
+              message -> {
+                final var someResponse = message.<SomeResponse>data();
+                assertNotNull(someResponse, "data");
+                assertEquals(param, someResponse.name(), "someResponse.name");
+              })
+          .verifyComplete();
     }
 
     @Test
-    void testTrace() throws Exception {
-      final var fooParam = "trace" + System.currentTimeMillis();
-      final var httpRequest =
-          HttpRequest.newBuilder(new URI(httpGatewayAddress + "/v1/restService/trace/" + fooParam))
-              .method("TRACE", BodyPublishers.noBody())
-              .build();
-      final var httpResponse = httpClient.send(httpRequest, BodyHandlers.ofString());
-      assertEquals(HttpResponseStatus.OK.code(), httpResponse.statusCode(), "statusCode");
-      assertEquals(
-          fooParam,
-          objectMapper.readValue(httpResponse.body(), SomeResponse.class).name(),
-          "response");
+    void testTrace() {
+      final var param = "trace" + System.currentTimeMillis();
+      StepVerifier.create(
+              serviceCall.requestOne(
+                  ServiceMessage.builder()
+                      .header("http.method", "TRACE")
+                      .qualifier("v1/restService/trace/" + param)
+                      .build(),
+                  SomeResponse.class))
+          .assertNext(
+              message -> {
+                final var someResponse = message.<SomeResponse>data();
+                assertNotNull(someResponse, "data");
+                assertEquals(param, someResponse.name(), "someResponse.name");
+              })
+          .verifyComplete();
     }
   }
 
   @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
   class RoutingTests {
 
-    @Test
-    void testMatchByGetMethod() throws Exception {
-      final var fooParam = "get" + System.currentTimeMillis();
-      final var httpRequest =
-          HttpRequest.newBuilder(
-                  new URI(httpGatewayAddress + "/v1/routingService/find/" + fooParam))
-              .method("GET", BodyPublishers.noBody())
-              .build();
-      final var httpResponse = httpClient.send(httpRequest, BodyHandlers.ofString());
-      assertEquals(HttpResponseStatus.OK.code(), httpResponse.statusCode(), "statusCode");
-      assertEquals(
-          fooParam,
-          objectMapper.readValue(httpResponse.body(), SomeResponse.class).name(),
-          "response");
+    private ServiceCall serviceCall;
+
+    @BeforeAll
+    void beforeAll() {
+      serviceCall =
+          new ServiceCall()
+              .transport(HttpGatewayClientTransport.builder().address(gatewayAddress).build())
+              .router(router);
+    }
+
+    @AfterAll
+    void afterAll() {
+      if (serviceCall != null) {
+        serviceCall.close();
+      }
     }
 
     @Test
-    void testMatchByPostMethod() throws Exception {
-      final var name = "name" + System.currentTimeMillis();
-      final var fooParam = "post" + System.currentTimeMillis();
-      final var httpRequest =
-          HttpRequest.newBuilder(
-                  new URI(httpGatewayAddress + "/v1/routingService/update/" + fooParam))
-              .method(
-                  "POST",
-                  BodyPublishers.ofString(
-                      objectMapper.writeValueAsString(new SomeRequest().name(name))))
-              .build();
-      final var httpResponse = httpClient.send(httpRequest, BodyHandlers.ofString());
-      assertEquals(HttpResponseStatus.OK.code(), httpResponse.statusCode(), "statusCode");
-      assertEquals(
-          name, objectMapper.readValue(httpResponse.body(), SomeResponse.class).name(), "response");
+    void testMatchByGetMethod() {
+      final var param = "get" + System.currentTimeMillis();
+      StepVerifier.create(
+              serviceCall.requestOne(
+                  ServiceMessage.builder()
+                      .header("http.method", "GET")
+                      .qualifier("v1/routingService/find/" + param)
+                      .build(),
+                  SomeResponse.class))
+          .assertNext(
+              message -> {
+                final var someResponse = message.<SomeResponse>data();
+                assertNotNull(someResponse, "data");
+                assertEquals(param, someResponse.name(), "someResponse.name");
+              })
+          .verifyComplete();
     }
 
     @Test
-    void testNoMatchByRestMethod() throws Exception {
+    void testMatchByPostMethod() {
       final var name = "name" + System.currentTimeMillis();
-      final var fooParam = "post" + System.currentTimeMillis();
+      final var param = "post" + System.currentTimeMillis();
+      StepVerifier.create(
+              serviceCall.requestOne(
+                  ServiceMessage.builder()
+                      .header("http.method", "POST")
+                      .qualifier("v1/routingService/update/" + param)
+                      .data(new SomeRequest().name(name))
+                      .build(),
+                  SomeResponse.class))
+          .assertNext(
+              message -> {
+                final var someResponse = message.<SomeResponse>data();
+                assertNotNull(someResponse, "data");
+                assertEquals(name, someResponse.name(), "someResponse.name");
+              })
+          .verifyComplete();
+    }
+
+    @Test
+    void testNoMatchByRestMethod() {
+      final var name = "name" + System.currentTimeMillis();
+      final var param = "post" + System.currentTimeMillis();
       final var nonMatchedRestMethod = "PUT";
-      final var httpRequest =
-          HttpRequest.newBuilder(
-                  new URI(httpGatewayAddress + "/v1/routingService/update/" + fooParam))
-              .method(
-                  nonMatchedRestMethod,
-                  BodyPublishers.ofString(
-                      objectMapper.writeValueAsString(new SomeRequest().name(name))))
-              .build();
-      final var httpResponse = httpClient.send(httpRequest, BodyHandlers.ofString());
-      assertEquals(
-          HttpResponseStatus.SERVICE_UNAVAILABLE.code(), httpResponse.statusCode(), "statusCode");
-      assertTrue(
-          objectMapper
-              .readValue(httpResponse.body(), ErrorData.class)
-              .getErrorMessage()
-              .startsWith("No reachable member with such service"));
+      StepVerifier.create(
+              serviceCall.requestOne(
+                  ServiceMessage.builder()
+                      .header("http.method", nonMatchedRestMethod)
+                      .qualifier("v1/routingService/update/" + param)
+                      .data(new SomeRequest().name(name))
+                      .build(),
+                  SomeResponse.class))
+          .verifyErrorSatisfies(
+              ex -> {
+                final var exception = (ServiceUnavailableException) ex;
+                assertEquals(503, exception.errorCode(), "errorCode");
+                assertThat(
+                    exception.getMessage(),
+                    Matchers.startsWith("No reachable member with such service"));
+              });
     }
 
     @Test

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestGatewayTest.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestGatewayTest.java
@@ -168,7 +168,7 @@ public class RestGatewayTest {
 
     @Test
     void testHead() {
-      final var param = "head" + System.currentTimeMillis();
+      final var param = "head123456";
       final var customHeader1 = "customHeader-" + System.currentTimeMillis();
       final var customHeader2 = "customHeader-" + System.currentTimeMillis();
       final var queryParam1 = "queryParam-" + System.currentTimeMillis();

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestGatewayTest.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestGatewayTest.java
@@ -275,6 +275,29 @@ public class RestGatewayTest {
               })
           .verifyComplete();
     }
+
+    @Test
+    void testAttributesPropagation() {
+      StepVerifier.create(
+              serviceCall.requestOne(
+                  ServiceMessage.builder()
+                      .header("http.method", "GET")
+                      .header("http.header.X-String-Header", "abc")
+                      .header("http.header.X-Int-Header", "123456789")
+                      .header("http.query.debug", "true")
+                      .header("http.query.x", "1")
+                      .header("http.query.y", "2")
+                      .qualifier("v1/restService/propagate/123/bar456/baz789")
+                      .build(),
+                  SomeResponse.class))
+          .assertNext(
+              message -> {
+                final var someResponse = message.<SomeResponse>data();
+                assertNotNull(someResponse, "data");
+                assertNotNull(someResponse.name(), "someResponse.name");
+              })
+          .verifyComplete();
+    }
   }
 
   @Nested

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestGatewayTest.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestGatewayTest.java
@@ -8,13 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.scalecube.services.Address;
 import io.scalecube.services.Microservices;
 import io.scalecube.services.Microservices.Context;
@@ -92,19 +85,6 @@ public class RestGatewayTest {
     if (microservices != null) {
       microservices.close();
     }
-  }
-
-  private static ObjectMapper objectMapper() {
-    ObjectMapper mapper = new ObjectMapper();
-    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
-    mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
-    mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-    mapper.setVisibility(PropertyAccessor.ALL, Visibility.ANY);
-    mapper.setSerializationInclusion(Include.NON_NULL);
-    mapper.configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
-    mapper.registerModule(new JavaTimeModule());
-    return mapper;
   }
 
   @Nested
@@ -186,7 +166,7 @@ public class RestGatewayTest {
                   SomeResponse.class))
           .assertNext(
               message -> {
-                assertNull(message.data(), "data");
+                assertNull(message.data(), "data"); // this is HEAD
                 assertNotNull(message.headers(), "headers");
                 assertThat(message.headers(), not(hasKey(HEADER_ERROR_TYPE)));
               })

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestService.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestService.java
@@ -1,5 +1,6 @@
 package io.scalecube.services.gateway.rest;
 
+import io.scalecube.services.annotations.RestMethod;
 import io.scalecube.services.annotations.Service;
 import io.scalecube.services.annotations.ServiceMethod;
 import reactor.core.publisher.Mono;
@@ -30,4 +31,8 @@ public interface RestService {
 
   @ServiceMethod("trace/:foo")
   Mono<SomeResponse> trace();
+
+  @RestMethod("GET")
+  @ServiceMethod("propagate/:foo/:bar/:baz")
+  Mono<SomeResponse> propagateRequestAttributes();
 }

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestService.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestService.java
@@ -26,7 +26,7 @@ public interface RestService {
   Mono<SomeResponse> patch(SomeRequest request);
 
   @ServiceMethod("delete/:foo")
-  Mono<SomeResponse> delete(SomeRequest request);
+  Mono<SomeResponse> delete();
 
   @ServiceMethod("trace/:foo")
   Mono<SomeResponse> trace();

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestServiceImpl.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestServiceImpl.java
@@ -17,7 +17,7 @@ public class RestServiceImpl implements RestService {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              final var foo = context.pathVar("foo");
+              final var foo = context.pathParam("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));
@@ -31,7 +31,7 @@ public class RestServiceImpl implements RestService {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              final var foo = context.pathVar("foo");
+              final var foo = context.pathParam("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));
@@ -45,7 +45,7 @@ public class RestServiceImpl implements RestService {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              final var foo = context.pathVar("foo");
+              final var foo = context.pathParam("foo");
               assertEquals("head123456", foo, "pathParam");
               final var headers = context.headers();
               assertNotNull(headers);
@@ -70,7 +70,7 @@ public class RestServiceImpl implements RestService {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              assertNotNull(context.pathVar("foo"));
+              assertNotNull(context.pathParam("foo"));
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));
               assertEquals("POST", context.requestMethod());
@@ -83,7 +83,7 @@ public class RestServiceImpl implements RestService {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              assertNotNull(context.pathVar("foo"));
+              assertNotNull(context.pathParam("foo"));
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));
               assertEquals("PUT", context.requestMethod());
@@ -96,7 +96,7 @@ public class RestServiceImpl implements RestService {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              assertNotNull(context.pathVar("foo"));
+              assertNotNull(context.pathParam("foo"));
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));
               assertEquals("PATCH", context.requestMethod());
@@ -109,7 +109,7 @@ public class RestServiceImpl implements RestService {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              final var foo = context.pathVar("foo");
+              final var foo = context.pathParam("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));
@@ -123,7 +123,7 @@ public class RestServiceImpl implements RestService {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              final var foo = context.pathVar("foo");
+              final var foo = context.pathParam("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestServiceImpl.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestServiceImpl.java
@@ -46,7 +46,7 @@ public class RestServiceImpl implements RestService {
         .map(
             context -> {
               final var foo = context.pathVar("foo");
-              assertNotNull(foo);
+              assertEquals("head123456", foo, "pathParam");
               final var headers = context.headers();
               assertNotNull(headers);
               assertThat(context.headers().size(), greaterThan(0));

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestServiceImpl.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestServiceImpl.java
@@ -17,7 +17,8 @@ public class RestServiceImpl implements RestService {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              final var foo = context.pathParam("foo");
+              final var pathParams = context.pathParams();
+              final var foo = pathParams.stringValue("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));
@@ -31,7 +32,8 @@ public class RestServiceImpl implements RestService {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              final var foo = context.pathParam("foo");
+              final var pathParams = context.pathParams();
+              final var foo = pathParams.stringValue("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));
@@ -45,7 +47,8 @@ public class RestServiceImpl implements RestService {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              final var foo = context.pathParam("foo");
+              final var pathParams = context.pathParams();
+              final var foo = pathParams.stringValue("foo");
               assertEquals("head123456", foo, "pathParam");
               final var headers = context.headers();
               assertNotNull(headers);
@@ -70,7 +73,9 @@ public class RestServiceImpl implements RestService {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              assertNotNull(context.pathParam("foo"));
+              final var pathParams = context.pathParams();
+              final var foo = pathParams.stringValue("foo");
+              assertNotNull(foo);
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));
               assertEquals("POST", context.requestMethod());
@@ -83,7 +88,9 @@ public class RestServiceImpl implements RestService {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              assertNotNull(context.pathParam("foo"));
+              final var pathParams = context.pathParams();
+              final var foo = pathParams.stringValue("foo");
+              assertNotNull(foo);
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));
               assertEquals("PUT", context.requestMethod());
@@ -96,7 +103,9 @@ public class RestServiceImpl implements RestService {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              assertNotNull(context.pathParam("foo"));
+              final var pathParams = context.pathParams();
+              final var foo = pathParams.stringValue("foo");
+              assertNotNull(foo);
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));
               assertEquals("PATCH", context.requestMethod());
@@ -109,7 +118,8 @@ public class RestServiceImpl implements RestService {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              final var foo = context.pathParam("foo");
+              final var pathParams = context.pathParams();
+              final var foo = pathParams.stringValue("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));
@@ -123,7 +133,8 @@ public class RestServiceImpl implements RestService {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              final var foo = context.pathParam("foo");
+              final var pathParams = context.pathParams();
+              final var foo = pathParams.stringValue("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestServiceImpl.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestServiceImpl.java
@@ -19,7 +19,7 @@ public class RestServiceImpl implements RestService {
         .map(
             context -> {
               final var pathParams = context.pathParams();
-              final var foo = pathParams.stringValue("foo");
+              final var foo = pathParams.getString("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));
@@ -34,7 +34,7 @@ public class RestServiceImpl implements RestService {
         .map(
             context -> {
               final var pathParams = context.pathParams();
-              final var foo = pathParams.stringValue("foo");
+              final var foo = pathParams.getString("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));
@@ -49,7 +49,7 @@ public class RestServiceImpl implements RestService {
         .map(
             context -> {
               final var pathParams = context.pathParams();
-              final var foo = pathParams.stringValue("foo");
+              final var foo = pathParams.getString("foo");
               assertEquals("head123456", foo, "pathParam");
               final var headers = context.headers();
               assertNotNull(headers);
@@ -75,7 +75,7 @@ public class RestServiceImpl implements RestService {
         .map(
             context -> {
               final var pathParams = context.pathParams();
-              final var foo = pathParams.stringValue("foo");
+              final var foo = pathParams.getString("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));
@@ -90,7 +90,7 @@ public class RestServiceImpl implements RestService {
         .map(
             context -> {
               final var pathParams = context.pathParams();
-              final var foo = pathParams.stringValue("foo");
+              final var foo = pathParams.getString("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));
@@ -105,7 +105,7 @@ public class RestServiceImpl implements RestService {
         .map(
             context -> {
               final var pathParams = context.pathParams();
-              final var foo = pathParams.stringValue("foo");
+              final var foo = pathParams.getString("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));
@@ -120,7 +120,7 @@ public class RestServiceImpl implements RestService {
         .map(
             context -> {
               final var pathParams = context.pathParams();
-              final var foo = pathParams.stringValue("foo");
+              final var foo = pathParams.getString("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));
@@ -135,7 +135,7 @@ public class RestServiceImpl implements RestService {
         .map(
             context -> {
               final var pathParams = context.pathParams();
-              final var foo = pathParams.stringValue("foo");
+              final var foo = pathParams.getString("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
               assertThat(context.headers().size(), greaterThan(0));
@@ -150,9 +150,9 @@ public class RestServiceImpl implements RestService {
         .map(
             context -> {
               final var pathParams = context.pathParams();
-              assertEquals(123, pathParams.intValue("foo"), "foo");
-              assertEquals("bar456", pathParams.stringValue("bar"), "bar");
-              assertEquals("baz789", pathParams.stringValue("baz"), "baz");
+              assertEquals(123, pathParams.getInt("foo"), "foo");
+              assertEquals("bar456", pathParams.getString("bar"), "bar");
+              assertEquals("baz789", pathParams.getString("baz"), "baz");
 
               final var headers = context.headers();
               assertEquals("GET", headers.get("http.method"));
@@ -163,13 +163,13 @@ public class RestServiceImpl implements RestService {
               assertEquals("2", headers.get("http.query.y"));
 
               final var httpHeaders = context.headerParams("http.header");
-              assertEquals("abc", httpHeaders.stringValue("X-String-Header"));
-              assertEquals(123456789, httpHeaders.intValue("X-Int-Header"));
+              assertEquals("abc", httpHeaders.getString("X-String-Header"));
+              assertEquals(123456789, httpHeaders.getInt("X-Int-Header"));
 
               final var queryParams = context.headerParams("http.query");
-              assertEquals(true, queryParams.booleanValue("debug"));
-              assertEquals(1, queryParams.intValue("x"));
-              assertEquals(2, queryParams.intValue("y"));
+              assertEquals(true, queryParams.getBoolean("debug"));
+              assertEquals(1, queryParams.getInt("x"));
+              assertEquals(2, queryParams.getInt("y"));
 
               return new SomeResponse().name(UUID.randomUUID().toString());
             });

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestServiceImpl.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestServiceImpl.java
@@ -91,15 +91,16 @@ public class RestServiceImpl implements RestService {
   }
 
   @Override
-  public Mono<SomeResponse> delete(SomeRequest request) {
+  public Mono<SomeResponse> delete() {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              assertNotNull(context.pathVar("foo"));
+              final var foo = context.pathVar("foo");
+              assertNotNull(foo);
               assertNotNull(context.headers());
               assertTrue(context.headers().size() > 0);
               assertEquals("DELETE", context.requestMethod());
-              return new SomeResponse().name(request.name());
+              return new SomeResponse().name(foo);
             });
   }
 

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestServiceImpl.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestServiceImpl.java
@@ -1,8 +1,11 @@
 package io.scalecube.services.gateway.rest;
 
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasKey;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.scalecube.services.RequestContext;
 import reactor.core.publisher.Mono;
@@ -17,7 +20,7 @@ public class RestServiceImpl implements RestService {
               final var foo = context.pathVar("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
-              assertTrue(context.headers().size() > 0);
+              assertThat(context.headers().size(), greaterThan(0));
               assertEquals("OPTIONS", context.requestMethod());
               return new SomeResponse().name(foo);
             });
@@ -31,7 +34,7 @@ public class RestServiceImpl implements RestService {
               final var foo = context.pathVar("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
-              assertTrue(context.headers().size() > 0);
+              assertThat(context.headers().size(), greaterThan(0));
               assertEquals("GET", context.requestMethod());
               return new SomeResponse().name(foo);
             });
@@ -44,9 +47,20 @@ public class RestServiceImpl implements RestService {
             context -> {
               final var foo = context.pathVar("foo");
               assertNotNull(foo);
-              assertNotNull(context.headers());
-              assertTrue(context.headers().size() > 0);
+              final var headers = context.headers();
+              assertNotNull(headers);
+              assertThat(context.headers().size(), greaterThan(0));
               assertEquals("HEAD", context.requestMethod());
+
+              assertThat(
+                  headers,
+                  allOf(
+                      hasKey("http.method"),
+                      hasKey("http.header.X-Custom-Header-1"),
+                      hasKey("http.header.X-Custom-Header-2"),
+                      hasKey("http.query.param1"),
+                      hasKey("http.query.param2")));
+
               return new SomeResponse().name(foo);
             });
   }
@@ -58,7 +72,7 @@ public class RestServiceImpl implements RestService {
             context -> {
               assertNotNull(context.pathVar("foo"));
               assertNotNull(context.headers());
-              assertTrue(context.headers().size() > 0);
+              assertThat(context.headers().size(), greaterThan(0));
               assertEquals("POST", context.requestMethod());
               return new SomeResponse().name(request.name());
             });
@@ -71,7 +85,7 @@ public class RestServiceImpl implements RestService {
             context -> {
               assertNotNull(context.pathVar("foo"));
               assertNotNull(context.headers());
-              assertTrue(context.headers().size() > 0);
+              assertThat(context.headers().size(), greaterThan(0));
               assertEquals("PUT", context.requestMethod());
               return new SomeResponse().name(request.name());
             });
@@ -84,7 +98,7 @@ public class RestServiceImpl implements RestService {
             context -> {
               assertNotNull(context.pathVar("foo"));
               assertNotNull(context.headers());
-              assertTrue(context.headers().size() > 0);
+              assertThat(context.headers().size(), greaterThan(0));
               assertEquals("PATCH", context.requestMethod());
               return new SomeResponse().name(request.name());
             });
@@ -98,7 +112,7 @@ public class RestServiceImpl implements RestService {
               final var foo = context.pathVar("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
-              assertTrue(context.headers().size() > 0);
+              assertThat(context.headers().size(), greaterThan(0));
               assertEquals("DELETE", context.requestMethod());
               return new SomeResponse().name(foo);
             });
@@ -112,7 +126,7 @@ public class RestServiceImpl implements RestService {
               final var foo = context.pathVar("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
-              assertTrue(context.headers().size() > 0);
+              assertThat(context.headers().size(), greaterThan(0));
               assertEquals("TRACE", context.requestMethod());
               return new SomeResponse().name(foo);
             });

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RoutingServiceImpl.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RoutingServiceImpl.java
@@ -15,7 +15,7 @@ public class RoutingServiceImpl implements RoutingService {
         .map(
             context -> {
               final var pathParams = context.pathParams();
-              final var foo = pathParams.stringValue("foo");
+              final var foo = pathParams.getString("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
               assertTrue(context.headers().size() > 0);
@@ -30,7 +30,7 @@ public class RoutingServiceImpl implements RoutingService {
         .map(
             context -> {
               final var pathParams = context.pathParams();
-              final var foo = pathParams.stringValue("foo");
+              final var foo = pathParams.getString("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
               assertTrue(context.headers().size() > 0);

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RoutingServiceImpl.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RoutingServiceImpl.java
@@ -14,7 +14,7 @@ public class RoutingServiceImpl implements RoutingService {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              final var foo = context.pathVar("foo");
+              final var foo = context.pathParam("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
               assertTrue(context.headers().size() > 0);
@@ -28,7 +28,7 @@ public class RoutingServiceImpl implements RoutingService {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              assertNotNull(context.pathVar("foo"));
+              assertNotNull(context.pathParam("foo"));
               assertNotNull(context.headers());
               assertTrue(context.headers().size() > 0);
               assertEquals("POST", context.requestMethod());

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RoutingServiceImpl.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RoutingServiceImpl.java
@@ -14,7 +14,8 @@ public class RoutingServiceImpl implements RoutingService {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              final var foo = context.pathParam("foo");
+              final var pathParams = context.pathParams();
+              final var foo = pathParams.stringValue("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
               assertTrue(context.headers().size() > 0);
@@ -28,7 +29,9 @@ public class RoutingServiceImpl implements RoutingService {
     return RequestContext.deferContextual()
         .map(
             context -> {
-              assertNotNull(context.pathParam("foo"));
+              final var pathParams = context.pathParams();
+              final var foo = pathParams.stringValue("foo");
+              assertNotNull(foo);
               assertNotNull(context.headers());
               assertTrue(context.headers().size() > 0);
               assertEquals("POST", context.requestMethod());

--- a/services/src/main/java/io/scalecube/services/files/FileServiceImpl.java
+++ b/services/src/main/java/io/scalecube/services/files/FileServiceImpl.java
@@ -97,7 +97,7 @@ public class FileServiceImpl implements FileService, FileStreamer {
             context -> {
               final var headers = context.headers();
               final var pathParams = context.pathParams();
-              final var filename = pathParams.stringValue("filename");
+              final var filename = pathParams.getString("filename");
               final var path = baseDir.resolve(filename);
 
               if (!isPathValid(path)) {

--- a/services/src/main/java/io/scalecube/services/files/FileServiceImpl.java
+++ b/services/src/main/java/io/scalecube/services/files/FileServiceImpl.java
@@ -96,7 +96,7 @@ public class FileServiceImpl implements FileService, FileStreamer {
         .flatMapMany(
             context -> {
               final var headers = context.headers();
-              final var filename = context.pathVar("filename");
+              final var filename = context.pathParam("filename");
               final var path = baseDir.resolve(filename);
 
               if (!isPathValid(path)) {

--- a/services/src/main/java/io/scalecube/services/files/FileServiceImpl.java
+++ b/services/src/main/java/io/scalecube/services/files/FileServiceImpl.java
@@ -96,7 +96,8 @@ public class FileServiceImpl implements FileService, FileStreamer {
         .flatMapMany(
             context -> {
               final var headers = context.headers();
-              final var filename = context.pathParam("filename");
+              final var pathParams = context.pathParams();
+              final var filename = pathParams.stringValue("filename");
               final var path = baseDir.resolve(filename);
 
               if (!isPathValid(path)) {

--- a/services/src/test/java/io/scalecube/services/PlaceholderQualifierTest.java
+++ b/services/src/test/java/io/scalecube/services/PlaceholderQualifierTest.java
@@ -170,7 +170,7 @@ public class PlaceholderQualifierTest {
     @Override
     public Mono<String> helloWithPathParam() {
       return RequestContext.deferContextual()
-          .map(context -> id + "|" + context.pathParams().stringValue("name"));
+          .map(context -> id + "|" + context.pathParams().getString("name"));
     }
   }
 }

--- a/services/src/test/java/io/scalecube/services/PlaceholderQualifierTest.java
+++ b/services/src/test/java/io/scalecube/services/PlaceholderQualifierTest.java
@@ -86,7 +86,7 @@ public class PlaceholderQualifierTest {
   }
 
   @Test
-  void shouldRouteByPlaceholderQualifierWithPathVar() {
+  void shouldRouteByPlaceholderQualifierWithPathParam() {
     final var foo1Id = providerFoo1.id();
     final var name1 = "name1";
     final String foo1Result =
@@ -150,7 +150,7 @@ public class PlaceholderQualifierTest {
     Mono<String> hello();
 
     @ServiceMethod("hello/${microservices:id}/:name")
-    Mono<String> helloWithPathVar();
+    Mono<String> helloWithPathParam();
   }
 
   public static class FooServiceImpl implements FooService {
@@ -168,8 +168,8 @@ public class PlaceholderQualifierTest {
     }
 
     @Override
-    public Mono<String> helloWithPathVar() {
-      return RequestContext.deferContextual().map(context -> id + "|" + context.pathVar("name"));
+    public Mono<String> helloWithPathParam() {
+      return RequestContext.deferContextual().map(context -> id + "|" + context.pathParam("name"));
     }
   }
 }

--- a/services/src/test/java/io/scalecube/services/PlaceholderQualifierTest.java
+++ b/services/src/test/java/io/scalecube/services/PlaceholderQualifierTest.java
@@ -169,7 +169,8 @@ public class PlaceholderQualifierTest {
 
     @Override
     public Mono<String> helloWithPathParam() {
-      return RequestContext.deferContextual().map(context -> id + "|" + context.pathParam("name"));
+      return RequestContext.deferContextual()
+          .map(context -> id + "|" + context.pathParams().stringValue("name"));
     }
   }
 }

--- a/services/src/test/java/io/scalecube/services/ServiceRegistrationTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceRegistrationTest.java
@@ -1,4 +1,4 @@
-package io.scalecube.services.gateway.rest;
+package io.scalecube.services;
 
 import static io.scalecube.services.api.ServiceMessage.HEADER_REQUEST_METHOD;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
-import io.scalecube.services.Microservices;
 import io.scalecube.services.Microservices.Context;
 import io.scalecube.services.annotations.RestMethod;
 import io.scalecube.services.annotations.Service;
@@ -117,7 +116,7 @@ public class ServiceRegistrationTest {
   interface EchoService {
 
     @ServiceMethod("get/:foo")
-    Mono<SomeResponse> echo();
+    Mono<String> echo();
   }
 
   @Service("v1/service")
@@ -125,11 +124,11 @@ public class ServiceRegistrationTest {
 
     @RestMethod("GET")
     @ServiceMethod("get/:foo")
-    Mono<SomeResponse> echo();
+    Mono<String> echo();
 
     @RestMethod("GET")
     @ServiceMethod("get/:foo")
-    Mono<SomeResponse> ping();
+    Mono<String> ping();
   }
 
   @Service("v1/service")
@@ -137,11 +136,11 @@ public class ServiceRegistrationTest {
 
     @RestMethod("GET")
     @ServiceMethod("echo/:foo")
-    Mono<SomeResponse> echo();
+    Mono<String> echo();
 
     @RestMethod("POST")
     @ServiceMethod("echo/:foo")
-    Mono<SomeResponse> ping();
+    Mono<String> ping();
   }
 
   @Service("v1/service")
@@ -149,7 +148,7 @@ public class ServiceRegistrationTest {
 
     @RestMethod("POST")
     @ServiceMethod("account/:foo")
-    Mono<SomeResponse> account();
+    Mono<String> account();
   }
 
   @Service("v1/service")
@@ -157,6 +156,6 @@ public class ServiceRegistrationTest {
 
     @RestMethod("PUT")
     @ServiceMethod("account/:foo")
-    Mono<SomeResponse> account();
+    Mono<String> account();
   }
 }

--- a/services/src/test/java/io/scalecube/services/registry/ServiceRegistryImplTest.java
+++ b/services/src/test/java/io/scalecube/services/registry/ServiceRegistryImplTest.java
@@ -78,7 +78,7 @@ class ServiceRegistryImplTest {
                           new HashMap<>(),
                           List.of(
                               ServiceMethodDefinition.fromAction("hello"),
-                              ServiceMethodDefinition.fromAction("hello/:pathVar")))))
+                              ServiceMethodDefinition.fromAction("hello/:pathParam")))))
               .build());
     }
 
@@ -136,7 +136,7 @@ class ServiceRegistryImplTest {
                           new HashMap<>(),
                           List.of(
                               ServiceMethodDefinition.fromAction("hello"),
-                              ServiceMethodDefinition.fromAction("hello/:pathVar")))))
+                              ServiceMethodDefinition.fromAction("hello/:pathParam")))))
               .build());
     }
     assertEquals(
@@ -194,8 +194,8 @@ class ServiceRegistryImplTest {
 
     String NAMESPACE = "greeting";
 
-    @ServiceMethod("hello/:pathVar")
-    default Mono<String> helloPathVar() {
+    @ServiceMethod("hello/:pathParam")
+    default Mono<String> helloPathParam() {
       return Mono.just("" + System.currentTimeMillis());
     }
   }
@@ -210,14 +210,14 @@ class ServiceRegistryImplTest {
     String NAMESPACE = "v1/api";
 
     @RestMethod("POST")
-    @ServiceMethod("foo/:pathVar")
-    default Mono<String> updateWithPathVar() {
+    @ServiceMethod("foo/:pathParam")
+    default Mono<String> updateWithPathParam() {
       return Mono.just("" + System.currentTimeMillis());
     }
 
     @RestMethod("POST")
     @ServiceMethod("foo/update")
-    default Mono<String> updateWithoutPathVar() {
+    default Mono<String> updateWithoutPathParam() {
       return Mono.just("" + System.currentTimeMillis());
     }
   }
@@ -228,14 +228,14 @@ class ServiceRegistryImplTest {
     String NAMESPACE = "v1/api";
 
     @RestMethod("PUT")
-    @ServiceMethod("foo/:pathVar")
-    default Mono<String> updateWithPathVar() {
+    @ServiceMethod("foo/:pathParam")
+    default Mono<String> updateWithPathParam() {
       return Mono.just("" + System.currentTimeMillis());
     }
 
     @RestMethod("PUT")
     @ServiceMethod("foo/update")
-    default Mono<String> updateWithoutPathVar() {
+    default Mono<String> updateWithoutPathParam() {
       return Mono.just("" + System.currentTimeMillis());
     }
   }

--- a/services/src/test/java/io/scalecube/services/sut/GreetingServiceImpl.java
+++ b/services/src/test/java/io/scalecube/services/sut/GreetingServiceImpl.java
@@ -205,6 +205,6 @@ public final class GreetingServiceImpl implements GreetingService {
   @Override
   public Mono<String> helloDynamicQualifier(Long value) {
     return RequestContext.deferContextual()
-        .map(context -> context.pathParam("someVar") + "@" + value);
+        .map(context -> context.pathParams().stringValue("someVar") + "@" + value);
   }
 }

--- a/services/src/test/java/io/scalecube/services/sut/GreetingServiceImpl.java
+++ b/services/src/test/java/io/scalecube/services/sut/GreetingServiceImpl.java
@@ -205,6 +205,6 @@ public final class GreetingServiceImpl implements GreetingService {
   @Override
   public Mono<String> helloDynamicQualifier(Long value) {
     return RequestContext.deferContextual()
-        .map(context -> context.pathParams().stringValue("someVar") + "@" + value);
+        .map(context -> context.pathParams().getString("someVar") + "@" + value);
   }
 }

--- a/services/src/test/java/io/scalecube/services/sut/GreetingServiceImpl.java
+++ b/services/src/test/java/io/scalecube/services/sut/GreetingServiceImpl.java
@@ -205,6 +205,6 @@ public final class GreetingServiceImpl implements GreetingService {
   @Override
   public Mono<String> helloDynamicQualifier(Long value) {
     return RequestContext.deferContextual()
-        .map(context -> context.pathVar("someVar") + "@" + value);
+        .map(context -> context.pathParam("someVar") + "@" + value);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/scalecube/scalecube-services/issues/945

**Changes:**

* Renamed "path variables" to "path params" or "path parameters".
* Enhanced `RequestContext` with typed access to all necessary HTTP request attributes: headers, path parameters, query parameters.
* Fixed bug when path params was being used together with query string.
* Fixed bug with duplicate qualifier name and rest-method.
* Enhanced HTTP client and backend side - `HttpGatewayClientTransport/HttpGatewayAcceptor`. 
* Migrated `RestGatewayTest` to `ServiceCall + HttpGatewayClientTransport`.