### PR TITLE
Replace hamcrest and assertJ assertions with JUnit 5 Assertions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.scalecube</groupId>
     <artifactId>scalecube-parent</artifactId>
-    <version>0.3.18</version>
+    <version>0.3.20-SNAPSHOT</version>
   </parent>
 
   <artifactId>scalecube-services-parent</artifactId>
@@ -59,7 +59,7 @@
   <properties>
     <scalecube-cluster.version>2.7.7</scalecube-cluster.version>
     <scalecube-security.version>1.1.11</scalecube-security.version>
-    <scalecube-test-support.version>0.1.4</scalecube-test-support.version>
+    <scalecube-test-support.version>0.1.5-SNAPSHOT</scalecube-test-support.version>
 
     <distributionManagement.url>https://maven.pkg.github.com/scalecube/scalecube-services
     </distributionManagement.url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.scalecube</groupId>
     <artifactId>scalecube-parent</artifactId>
-    <version>0.3.20-SNAPSHOT</version>
+    <version>0.3.20</version>
   </parent>
 
   <artifactId>scalecube-services-parent</artifactId>
@@ -59,7 +59,7 @@
   <properties>
     <scalecube-cluster.version>2.7.7</scalecube-cluster.version>
     <scalecube-security.version>1.1.11</scalecube-security.version>
-    <scalecube-test-support.version>0.1.5-SNAPSHOT</scalecube-test-support.version>
+    <scalecube-test-support.version>0.1.7</scalecube-test-support.version>
 
     <distributionManagement.url>https://maven.pkg.github.com/scalecube/scalecube-services
     </distributionManagement.url>

--- a/services-api/src/main/java/io/scalecube/services/exceptions/ServiceException.java
+++ b/services-api/src/main/java/io/scalecube/services/exceptions/ServiceException.java
@@ -21,10 +21,10 @@ public abstract class ServiceException extends RuntimeException {
     this.errorCode = errorCode;
   }
 
-  @Override
-  public synchronized Throwable fillInStackTrace() {
-    return this;
-  }
+  //  @Override
+  //  public synchronized Throwable fillInStackTrace() {
+  //    return this;
+  //  }
 
   public int errorCode() {
     return errorCode;

--- a/services-api/src/main/java/io/scalecube/services/exceptions/ServiceException.java
+++ b/services-api/src/main/java/io/scalecube/services/exceptions/ServiceException.java
@@ -21,10 +21,10 @@ public abstract class ServiceException extends RuntimeException {
     this.errorCode = errorCode;
   }
 
-  //  @Override
-  //  public synchronized Throwable fillInStackTrace() {
-  //    return this;
-  //  }
+  @Override
+  public synchronized Throwable fillInStackTrace() {
+    return this;
+  }
 
   public int errorCode() {
     return errorCode;

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/http/CorsTest.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/http/CorsTest.java
@@ -1,9 +1,8 @@
 package io.scalecube.services.gateway.http;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
@@ -82,9 +81,8 @@ public class CorsTest {
 
     assertEquals(HttpResponseStatus.OK, response.status());
     assertEquals("*", responseHeaders.get("Access-Control-Allow-Origin"));
-    assertThat(responseHeaders.get("Access-Control-Allow-Headers"), containsString("Content-Type"));
-    assertThat(
-        responseHeaders.get("Access-Control-Allow-Headers"), containsString("X-Correlation-ID"));
+    assertTrue(responseHeaders.get("Access-Control-Allow-Headers").contains("Content-Type"));
+    assertTrue(responseHeaders.get("Access-Control-Allow-Headers").contains("X-Correlation-ID"));
     final var allowedMethodsHeader = responseHeaders.get("Access-Control-Allow-Methods");
     assertEquals(
         HttpGateway.SUPPORTED_METHODS.stream().map(HttpMethod::name).collect(Collectors.toSet()),

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestGatewayTest.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestGatewayTest.java
@@ -1,12 +1,11 @@
 package io.scalecube.services.gateway.rest;
 
 import static io.scalecube.services.api.ServiceMessage.HEADER_ERROR_TYPE;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.scalecube.services.Address;
 import io.scalecube.services.Microservices;
@@ -27,7 +26,6 @@ import io.scalecube.transport.netty.websocket.WebsocketTransportFactory;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
@@ -170,7 +168,7 @@ public class RestGatewayTest {
               message -> {
                 assertNull(message.data(), "data"); // this is HEAD
                 assertNotNull(message.headers(), "headers");
-                assertThat(message.headers(), not(hasKey(HEADER_ERROR_TYPE)));
+                assertFalse(message.headers().containsKey(HEADER_ERROR_TYPE));
               })
           .verifyComplete();
     }
@@ -398,9 +396,7 @@ public class RestGatewayTest {
               ex -> {
                 final var exception = (ServiceUnavailableException) ex;
                 assertEquals(503, exception.errorCode(), "errorCode");
-                assertThat(
-                    exception.getMessage(),
-                    Matchers.startsWith("No reachable member with such service"));
+                assertTrue(exception.getMessage().startsWith("No reachable member with such service"));
               });
     }
 
@@ -414,14 +410,12 @@ public class RestGatewayTest {
       try (final var serviceCall = new ServiceCall().router(router).transport(clientTransport)) {
         StepVerifier.create(serviceCall.api(RoutingService.class).update(new SomeRequest()))
             .expectSubscription()
-            .expectErrorSatisfies(
-                ex -> {
-                  final var exception = (ServiceUnavailableException) ex;
-                  assertEquals(503, exception.errorCode());
-                  assertThat(
-                      exception.getMessage(),
-                      Matchers.startsWith("No reachable member with such service"));
-                })
+                .expectErrorSatisfies(
+                    ex -> {
+                      final var exception = (ServiceUnavailableException) ex;
+                      assertEquals(503, exception.errorCode());
+                      assertTrue(exception.getMessage().startsWith("No reachable member with such service"));
+                    })
             .verify(Duration.ofSeconds(3));
       }
     }

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestServiceImpl.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/rest/RestServiceImpl.java
@@ -1,11 +1,8 @@
 package io.scalecube.services.gateway.rest;
 
-import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasKey;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.scalecube.services.RequestContext;
 import java.util.UUID;
@@ -22,7 +19,7 @@ public class RestServiceImpl implements RestService {
               final var foo = pathParams.getString("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
-              assertThat(context.headers().size(), greaterThan(0));
+              assertTrue(context.headers().size() > 0);
               assertEquals("OPTIONS", context.requestMethod());
               return new SomeResponse().name(foo);
             });
@@ -37,7 +34,7 @@ public class RestServiceImpl implements RestService {
               final var foo = pathParams.getString("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
-              assertThat(context.headers().size(), greaterThan(0));
+              assertTrue(context.headers().size() > 0);
               assertEquals("GET", context.requestMethod());
               return new SomeResponse().name(foo);
             });
@@ -53,17 +50,14 @@ public class RestServiceImpl implements RestService {
               assertEquals("head123456", foo, "pathParam");
               final var headers = context.headers();
               assertNotNull(headers);
-              assertThat(context.headers().size(), greaterThan(0));
+              assertTrue(context.headers().size() > 0);
               assertEquals("HEAD", context.requestMethod());
 
-              assertThat(
-                  headers,
-                  allOf(
-                      hasKey("http.method"),
-                      hasKey("http.header.X-Custom-Header-1"),
-                      hasKey("http.header.X-Custom-Header-2"),
-                      hasKey("http.query.param1"),
-                      hasKey("http.query.param2")));
+              assertTrue(headers.containsKey("http.method"));
+              assertTrue(headers.containsKey("http.header.X-Custom-Header-1"));
+              assertTrue(headers.containsKey("http.header.X-Custom-Header-2"));
+              assertTrue(headers.containsKey("http.query.param1"));
+              assertTrue(headers.containsKey("http.query.param2"));
 
               return new SomeResponse().name(foo);
             });
@@ -78,7 +72,7 @@ public class RestServiceImpl implements RestService {
               final var foo = pathParams.getString("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
-              assertThat(context.headers().size(), greaterThan(0));
+              assertTrue(context.headers().size() > 0);
               assertEquals("POST", context.requestMethod());
               return new SomeResponse().name(request.name());
             });
@@ -93,7 +87,7 @@ public class RestServiceImpl implements RestService {
               final var foo = pathParams.getString("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
-              assertThat(context.headers().size(), greaterThan(0));
+              assertTrue(context.headers().size() > 0);
               assertEquals("PUT", context.requestMethod());
               return new SomeResponse().name(request.name());
             });
@@ -108,7 +102,7 @@ public class RestServiceImpl implements RestService {
               final var foo = pathParams.getString("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
-              assertThat(context.headers().size(), greaterThan(0));
+              assertTrue(context.headers().size() > 0);
               assertEquals("PATCH", context.requestMethod());
               return new SomeResponse().name(request.name());
             });
@@ -123,7 +117,7 @@ public class RestServiceImpl implements RestService {
               final var foo = pathParams.getString("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
-              assertThat(context.headers().size(), greaterThan(0));
+              assertTrue(context.headers().size() > 0);
               assertEquals("DELETE", context.requestMethod());
               return new SomeResponse().name(foo);
             });
@@ -138,7 +132,7 @@ public class RestServiceImpl implements RestService {
               final var foo = pathParams.getString("foo");
               assertNotNull(foo);
               assertNotNull(context.headers());
-              assertThat(context.headers().size(), greaterThan(0));
+              assertTrue(context.headers().size() > 0);
               assertEquals("TRACE", context.requestMethod());
               return new SomeResponse().name(foo);
             });

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/websocket/WebsocketGatewayTest.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/websocket/WebsocketGatewayTest.java
@@ -1,11 +1,10 @@
 package io.scalecube.services.gateway.websocket;
 
 import static io.scalecube.services.gateway.GatewayErrorMapperImpl.ERROR_MAPPER;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.scalecube.services.Address;
 import io.scalecube.services.Microservices;
@@ -191,7 +190,7 @@ class WebsocketGatewayTest {
         .verifyErrorSatisfies(
             ex -> {
               assertInstanceOf(BadRequestException.class, ex);
-              assertThat(ex.getMessage(), startsWith("Wrong request"));
+              assertTrue(ex.getMessage().startsWith("Wrong request"));
             });
   }
 

--- a/services-gateway/src/test/java/io/scalecube/services/gateway/websocket/WebsocketLocalGatewayTest.java
+++ b/services-gateway/src/test/java/io/scalecube/services/gateway/websocket/WebsocketLocalGatewayTest.java
@@ -1,11 +1,10 @@
 package io.scalecube.services.gateway.websocket;
 
 import static io.scalecube.services.gateway.GatewayErrorMapperImpl.ERROR_MAPPER;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.scalecube.services.Address;
 import io.scalecube.services.Microservices;
@@ -171,7 +170,7 @@ class WebsocketLocalGatewayTest {
         .verifyErrorSatisfies(
             ex -> {
               assertInstanceOf(BadRequestException.class, ex);
-              assertThat(ex.getMessage(), startsWith("Wrong request"));
+              assertTrue(ex.getMessage().startsWith("Wrong request"));
             });
   }
 

--- a/services/src/test/java/io/scalecube/services/ExecuteOnTest.java
+++ b/services/src/test/java/io/scalecube/services/ExecuteOnTest.java
@@ -1,7 +1,5 @@
 package io.scalecube.services;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -163,16 +161,16 @@ public class ExecuteOnTest {
       final var api = microservices.call().api(DefaultSchedulerOnServiceMethod.class);
 
       api.parallel().block();
-      assertThat(service.threadName.get(), startsWith("parallel"));
+      assertTrue(service.threadName.get().startsWith("parallel"));
 
       api.single().block();
-      assertThat(service.threadName.get(), startsWith("single"));
+      assertTrue(service.threadName.get().startsWith("single"));
 
       api.boundedElastic().block();
-      assertThat(service.threadName.get(), startsWith("boundedElastic"));
+      assertTrue(service.threadName.get().startsWith("boundedElastic"));
 
       api.immediate().block();
-      assertThat(service.threadName.get(), startsWith("main"));
+      assertTrue(service.threadName.get().startsWith("main"));
     }
   }
 
@@ -184,7 +182,7 @@ public class ExecuteOnTest {
       final var api = microservices.call().api(DefaultSchedulerOnService.class);
 
       api.hello().block();
-      assertThat(service.threadName.get(), startsWith("single"));
+      assertTrue(service.threadName.get().startsWith("single"));
     }
   }
 

--- a/services/src/test/java/io/scalecube/services/ServiceCallRemoteTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceCallRemoteTest.java
@@ -10,9 +10,8 @@ import static io.scalecube.services.TestRequests.GREETING_REQUEST_REQ;
 import static io.scalecube.services.TestRequests.GREETING_REQUEST_TIMEOUT_REQ;
 import static io.scalecube.services.TestRequests.GREETING_THROWING_VOID_REQ;
 import static io.scalecube.services.TestRequests.GREETING_VOID_REQ;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -208,7 +207,7 @@ public class ServiceCallRemoteTest {
               // print the greeting.
               System.out.println("10. remote_async_greeting_return_Message :" + result.data());
               // print the greeting.
-              assertThat(result.data(), instanceOf(GreetingResponse.class));
+              assertInstanceOf(GreetingResponse.class, result.data());
               assertEquals(" hello to: joe", ((GreetingResponse) result.data()).result());
             });
   }

--- a/services/src/test/java/io/scalecube/services/ServiceRegistrationTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceRegistrationTest.java
@@ -1,10 +1,10 @@
 package io.scalecube.services;
 
 import static io.scalecube.services.api.ServiceMessage.HEADER_REQUEST_METHOD;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
@@ -13,7 +13,6 @@ import io.scalecube.services.annotations.RestMethod;
 import io.scalecube.services.annotations.Service;
 import io.scalecube.services.annotations.ServiceMethod;
 import io.scalecube.services.api.ServiceMessage;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -36,7 +35,7 @@ public class ServiceRegistrationTest {
       fail("Expected exception");
     } catch (Exception e) {
       assertInstanceOf(IllegalStateException.class, e, e::getMessage);
-      assertThat(e.getMessage(), Matchers.startsWith("MethodInvoker already exists"));
+      assertTrue(e.getMessage().startsWith("MethodInvoker already exists"));
     }
   }
 
@@ -47,7 +46,7 @@ public class ServiceRegistrationTest {
       fail("Expected exception");
     } catch (Exception e) {
       assertInstanceOf(IllegalStateException.class, e, e::getMessage);
-      assertThat(e.getMessage(), Matchers.startsWith("MethodInvoker already exists"));
+      assertTrue(e.getMessage().startsWith("MethodInvoker already exists"));
     }
   }
 

--- a/services/src/test/java/io/scalecube/services/auth/ServiceRolesProcessorTest.java
+++ b/services/src/test/java/io/scalecube/services/auth/ServiceRolesProcessorTest.java
@@ -1,6 +1,5 @@
 package io.scalecube.services.auth;
 
-import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;


### PR DESCRIPTION
## Summary
Replaced all hamcrest and assertJ assertions in scalecube-services test code with corresponding JUnit 5 (org.junit.jupiter.api.Assertions) equivalents.

## Changes Made
- Removed all hamcrest imports (MatcherAssert, Matchers)
- Removed all assertJ imports
- Replaced assertThat() calls with appropriate JUnit 5 assertions:
  - assertThat(containsString()) → assertTrue(contains())
  - assertThat(startsWith()) → assertTrue(startsWith())
  - assertThat(instanceOf()) → assertInstanceOf()
  - assertThat(greaterThan(0)) → assertTrue(> 0)
  - assertThat(not(hasKey())) → assertFalse(containsKey())
  - assertThat(hasKey()) → assertTrue(containsKey())
