### PR TITLE
Add RSocket message-size limits: fragmentation + streaming high-watermark

### DIFF
--- a/docs/adr/0001-rsocket-message-size-limits.md
+++ b/docs/adr/0001-rsocket-message-size-limits.md
@@ -101,6 +101,13 @@ and composes with this one.
     encoding; pagination/streaming at the service is still required for truly unbounded queries.
   - `maxMessageSize` used as an inbound cap must be `>=` the 16 MB frame cap; smaller values bound
     only the outbound encode (documented on the setter).
+  - The limit is on the encoded **data** payload, not the full RSocket payload — a message's
+    headers/metadata are not counted, so the on-wire payload is slightly larger than the watermark.
+  - The encode-time `413` is shaped by `DefaultErrorMapper`, not a service's configured
+    `ServiceProviderErrorMapper`: the error arises in the transport (`RSocketImpl`), below the method
+    invoker that holds the configured mapper. A service with a custom provider error mapper will see
+    this one error use the default shape. Plumbing the configured mapper into the transport is a
+    possible follow-up if it ever matters.
   - Pre-existing, out-of-scope: a `Mono<byte[]>` service method cannot receive error responses —
     `ServiceMessageCodec.decodeData` decodes a `byte[]`-typed response before checking `isError()`,
     so the client gets the error bytes as a value. Tracked for a separate PR (move the `isError`

--- a/docs/adr/0001-rsocket-message-size-limits.md
+++ b/docs/adr/0001-rsocket-message-size-limits.md
@@ -1,0 +1,126 @@
+# 0001 — RSocket message-size limits: fragmentation + a streaming high-watermark
+
+Status: Proposed
+
+## Context
+
+A production service returned an unbounded result set (a "fetch everything" query) as a single
+RSocket response. The encoded payload exceeded RSocket's maximum single-frame length and the
+responder failed with:
+
+```
+io.rsocket.exceptions.CanceledException: The payload is too big to be send as a single frame
+with a max frame length 16777215. Consider enabling fragmentation.
+```
+
+The gateway (the caller) received this as an RSocket ERROR frame and relayed it to the external
+client as a generic `errorCode: 500`.
+
+Two facts frame the problem:
+
+- **The 16 MB cap is a fixed protocol constant.** RSocket's frame-length header is 24 bits, so no
+  single, non-fragmented frame can exceed `2^24 - 1 = 16_777_215` bytes (`FrameLengthCodec`). It
+  cannot be raised.
+- **scalecube-services builds the RSocket server/connector internally** (`RSocketServerTransport`,
+  `RSocketClientTransport`) and exposed no hook to configure framing — so neither fragmentation nor
+  any size limit could be set by a consumer of this library. The fix has to live here.
+
+Failure modes to address, in order of importance:
+
+1. A legitimately large response (bigger than one frame but bounded) cannot be sent at all.
+2. A response with no size bound produces a cryptic transport error (`CanceledException`) rather
+   than an actionable business error.
+3. An unbounded response can exhaust memory — on the sender while serializing, and on the receiver
+   while reassembling.
+
+The deeper product issue (an unbounded query) is out of scope for the transport: the transport
+cannot stop a service from OOMing while building its own result objects. That requires bounding the
+query (pagination/streaming) at the service. This ADR covers only what the transport can guarantee.
+
+## Alternatives considered
+
+1. **Do nothing in this repo; bound the response at the service (pagination / limits / streaming).**
+   Buys: addresses the root cause (an unbounded result set) with zero transport change; a streamed
+   `Flux<T>` never produces an oversized frame because each element is its own frame. Costs: doesn't
+   generalize — every service must remember to bound every response, and a forgotten bound reproduces
+   the incident with the same cryptic error; provides no defense-in-depth at the transport. *This remains the correct product fix and is complementary, not exclusive.*
+
+2. **Enable RSocket fragmentation only (`fragment(mtu)`), no size limit.** Buys: lifts the 16 MB cap
+   so large responses transmit (split into frames, reassembled on receipt). Costs: removes the only
+   guardrail — RSocket then accepts payloads up to `maxInboundPayloadSize` (default ~2 GiB), so an
+   unbounded response silently marches toward OOM instead of failing. Fragmentation alone trades a
+   loud, early failure for a quiet, late one.
+
+3. **Encode the whole response, then check its size and reject if too big.** Buys: a clean business
+   error at a chosen ceiling. Costs: not OOM-safe — the oversized payload is fully materialized into
+   a buffer *before* the size is known, so a runaway response OOMs the encoder before the check runs.
+
+4. **Streaming-encode with an abort-early size guard, plus fragmentation, plus an inbound reassembly
+   cap (chosen).** Buys: large-but-bounded responses succeed (fragmentation); anything past a
+   configured high-watermark fails fast with a typed `413` business error *during* encoding, so the
+   payload is never fully materialized (OOM-safe on send); inbound reassembly is capped so a peer
+   that ignores the watermark cannot OOM the receiver (OOM-safe on receive). Costs: more moving parts;
+   the watermark, when it also drives `maxInboundPayloadSize`, must be `>=` the 16 MB frame cap
+   (RSocket forbids a smaller inbound cap), so a sub-frame-cap watermark bounds only the outbound
+   encode.
+
+## Decision
+
+Expose two opt-in knobs on `RSocketServiceTransport`, default off (`0`), so existing behavior is
+unchanged:
+
+- **`mtu(int)`** — enable RSocket fragmentation on both the server and client (`RSocketServer
+  .fragment` / `RSocketConnector.fragment`). Lets a payload larger than the single-frame cap be sent
+  in pieces and reassembled.
+
+- **`maxMessageSize(int)`** — the high-watermark. It does two things:
+  - **Outbound (sender):** encoding runs through a streaming guard (`LimitedOutputStream`) that
+    aborts the instant the running byte count would cross the watermark, throwing
+    `MessageTooLargeException` (error code `413`). The responder converts this to a normal service
+    error message via the error mapper; the client request path lets it propagate directly. The
+    oversized payload is never fully materialized — OOM-safe on send — and the caller gets an
+    actionable `413` instead of a cryptic `CanceledException`.
+  - **Inbound (receiver):** when the watermark is `>=` the single-frame cap, it is also applied as
+    RSocket's `maxInboundPayloadSize` on both ends, so reassembly of an oversized payload is rejected
+    — OOM-safe on receive. Below the frame cap the inbound cap is not set (RSocket requires it to be
+    at least one frame), so a small watermark bounds only the outbound encode.
+
+This is chosen over the alternatives because it is the only option that is simultaneously
+(a) able to send legitimately large responses, (b) loud-and-early rather than quiet-and-late on
+abuse, and (c) OOM-safe in both directions — while staying opt-in and backward-compatible. It does
+not replace alternative 1 (bounding the query at the service), which remains the right product fix
+and composes with this one.
+
+## Consequences
+
+- **Buys:** an unbounded result set now either succeeds (if within the watermark, via
+  fragmentation) or fails fast with a clear `413 "Message size exceeds limit (N bytes)"`; no cryptic
+  transport error; no OOM from serialization or reassembly within the transport's control.
+- **Costs / residual risk:**
+  - The transport cannot prevent a service from OOMing while building its own result objects before
+    encoding; pagination/streaming at the service is still required for truly unbounded queries.
+  - `maxMessageSize` used as an inbound cap must be `>=` the 16 MB frame cap; smaller values bound
+    only the outbound encode (documented on the setter).
+  - Pre-existing, out-of-scope: a `Mono<byte[]>` service method cannot receive error responses —
+    `ServiceMessageCodec.decodeData` decodes a `byte[]`-typed response before checking `isError()`,
+    so the client gets the error bytes as a value. Tracked for a separate PR (move the `isError`
+    check before the `byte[]` branch).
+- **Compatibility:** both knobs default to `0` (off); the legacy transport constructors are
+  preserved as overloads, so existing callers are unaffected. Fragmentation on a sender is
+  wire-compatible with any RSocket 1.1.x receiver (reassembly is always supported).
+
+## References
+
+- RSocket protocol — 24-bit frame-length field; `io.rsocket.frame.FrameLengthCodec.FRAME_LENGTH_MASK
+  = 16_777_215`; `RSocketServer/RSocketConnector.fragment(int)` and `.maxInboundPayloadSize(int)`
+  (rsocket-core 1.1.5). Adopting the established protocol mechanism rather than inventing one (E3/E4).
+- Nygard, *Release It!* — bounded resources / back-pressure / fail-fast as stability patterns; the
+  watermark is the "bounded queue + shed load" pattern applied to message size (E1).
+- Functional-core / injected-limits framing and "make the bad state unrepresentable by construction"
+  — the streaming guard makes an oversized buffer unbuildable rather than detected-after-the-fact
+  (engineering-standards D1/meta-principle 2).
+- Evidence (T-family): `LimitedOutputStreamTest` proves the streaming/abort-early guard allocation-
+  free; `RSocketLargePayloadTest` is the runnable case matrix (frame-cap fail/fragment, watermark
+  boundary, `413` + exact message, inbound-cap rejection, request-side guard, streaming control).
+- Evidence tier (E6): protocol behavior verified directly against `rsocket-core` 1.1.5 bytecode and
+  exercised by integration tests against a real transport — not from documentation alone.

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/LimitedOutputStream.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/LimitedOutputStream.java
@@ -1,0 +1,42 @@
+package io.scalecube.services.transport.rsocket;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Output stream that aborts encoding the moment the number of bytes written would exceed {@code
+ * limit}, throwing {@link MessageTooLargeException} <em>before</em> the bytes reach the underlying
+ * stream. This bounds memory during encoding: an oversized message can never be fully materialized
+ * into the target buffer, so a runaway response cannot OOM the encoder — it fails fast instead.
+ */
+final class LimitedOutputStream extends FilterOutputStream {
+
+  private final long limit;
+  private long written;
+
+  LimitedOutputStream(OutputStream out, long limit) {
+    super(out);
+    this.limit = limit;
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    ensureCapacity(1);
+    out.write(b);
+    written++;
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    ensureCapacity(len);
+    out.write(b, off, len);
+    written += len;
+  }
+
+  private void ensureCapacity(int n) {
+    if (written + n > limit) {
+      throw new MessageTooLargeException("Message size exceeds limit (" + limit + " bytes)");
+    }
+  }
+}

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/LimitedOutputStream.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/LimitedOutputStream.java
@@ -36,7 +36,7 @@ final class LimitedOutputStream extends FilterOutputStream {
 
   private void ensureCapacity(int n) {
     if (written + n > limit) {
-      throw new MessageTooLargeException("Message size exceeds limit (" + limit + " bytes)");
+      throw MessageTooLargeException.of(limit);
     }
   }
 }

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/MessageTooLargeException.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/MessageTooLargeException.java
@@ -1,0 +1,19 @@
+package io.scalecube.services.transport.rsocket;
+
+import io.scalecube.services.exceptions.InternalServiceException;
+
+/**
+ * Thrown when a message exceeds the configured maximum message size while being encoded. It carries
+ * error code {@code 413} ("payload too large") and is an {@link InternalServiceException} (error
+ * type {@code 500} on the wire), so it propagates to the caller as a normal service error — with the
+ * same {@code 413} code whether it originates on the responder (oversized response) or the client
+ * (oversized request) — rather than as a transport-level frame failure.
+ */
+public class MessageTooLargeException extends InternalServiceException {
+
+  public static final int ERROR_CODE = 413;
+
+  public MessageTooLargeException(String message) {
+    super(ERROR_CODE, message);
+  }
+}

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/MessageTooLargeException.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/MessageTooLargeException.java
@@ -16,4 +16,15 @@ public class MessageTooLargeException extends InternalServiceException {
   public MessageTooLargeException(String message) {
     super(ERROR_CODE, message);
   }
+
+  /**
+   * Creates an exception with the canonical message for a given limit. Single source of the message
+   * text so it is asserted in exactly one place.
+   *
+   * @param maxMessageSize the limit that was exceeded, in bytes
+   * @return new {@link MessageTooLargeException}
+   */
+  public static MessageTooLargeException of(long maxMessageSize) {
+    return new MessageTooLargeException("Message size exceeds limit (" + maxMessageSize + " bytes)");
+  }
 }

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketClientChannel.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketClientChannel.java
@@ -15,10 +15,16 @@ public class RSocketClientChannel implements ClientChannel {
 
   private final Mono<RSocket> rsocket;
   private final ServiceMessageCodec messageCodec;
+  private final int maxMessageSize;
 
   public RSocketClientChannel(Mono<RSocket> rsocket, ServiceMessageCodec codec) {
+    this(rsocket, codec, 0);
+  }
+
+  public RSocketClientChannel(Mono<RSocket> rsocket, ServiceMessageCodec codec, int maxMessageSize) {
     this.rsocket = rsocket;
     this.messageCodec = codec;
+    this.maxMessageSize = maxMessageSize;
   }
 
   @Override
@@ -46,7 +52,7 @@ public class RSocketClientChannel implements ClientChannel {
   }
 
   private Payload toPayload(ServiceMessage request) {
-    return messageCodec.encodeAndTransform(request, ByteBufPayload::create);
+    return messageCodec.encodeAndTransform(request, maxMessageSize, ByteBufPayload::create);
   }
 
   private ServiceMessage toMessage(Payload payload) {

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketClientTransport.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketClientTransport.java
@@ -27,6 +27,10 @@ public class RSocketClientTransport implements ClientTransport {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RSocketClientTransport.class);
 
+  // RSocket 24-bit frame-length cap. maxInboundPayloadSize must be >= this (a reassembly buffer must
+  // hold at least one full frame), so the inbound cap is only meaningful when the watermark is >= it.
+  private static final int MAX_FRAME_LENGTH = 0xFFFFFF;
+
   private final Map<Destination, Mono<RSocket>> rsockets = new ConcurrentHashMap<>();
 
   private final HeadersCodec headersCodec;
@@ -34,9 +38,11 @@ public class RSocketClientTransport implements ClientTransport {
   private final RSocketClientTransportFactory clientTransportFactory;
   private final CredentialsSupplier credentialsSupplier;
   private final Collection<String> allowedRoles;
+  private final int mtu;
+  private final int maxMessageSize;
 
   /**
-   * Constructor.
+   * Constructor. Fragmentation is disabled and message size is unbounded.
    *
    * @param headersCodec headersCodec
    * @param dataCodecs dataCodecs
@@ -50,11 +56,40 @@ public class RSocketClientTransport implements ClientTransport {
       RSocketClientTransportFactory clientTransportFactory,
       CredentialsSupplier credentialsSupplier,
       Collection<String> allowedRoles) {
+    this(headersCodec, dataCodecs, clientTransportFactory, credentialsSupplier, allowedRoles, 0, 0);
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param headersCodec headersCodec
+   * @param dataCodecs dataCodecs
+   * @param clientTransportFactory clientTransportFactory
+   * @param credentialsSupplier credentialsSupplier (optional)
+   * @param allowedRoles allowedRoles (optional)
+   * @param mtu fragmentation MTU in bytes; {@code 0} disables fragmentation (see {@link
+   *     io.rsocket.core.RSocketConnector#fragment(int)})
+   * @param maxMessageSize maximum message size in bytes; {@code 0} means unbounded. Bounds both the
+   *     encoded request size (requests larger than this fail fast with {@link
+   *     MessageTooLargeException} instead of being framed) and inbound reassembly (see {@link
+   *     io.rsocket.core.RSocketConnector#maxInboundPayloadSize(int)}), preventing OOM in either
+   *     direction.
+   */
+  public RSocketClientTransport(
+      HeadersCodec headersCodec,
+      Collection<DataCodec> dataCodecs,
+      RSocketClientTransportFactory clientTransportFactory,
+      CredentialsSupplier credentialsSupplier,
+      Collection<String> allowedRoles,
+      int mtu,
+      int maxMessageSize) {
     this.headersCodec = headersCodec;
     this.dataCodecs = dataCodecs;
     this.clientTransportFactory = clientTransportFactory;
     this.credentialsSupplier = credentialsSupplier;
     this.allowedRoles = allowedRoles;
+    this.mtu = mtu;
+    this.maxMessageSize = maxMessageSize;
   }
 
   @Override
@@ -71,7 +106,8 @@ public class RSocketClientTransport implements ClientTransport {
                     .cacheInvalidateIf(RSocket::isDisposed)
                     .doOnError(ex -> monoMap.remove(destination)));
 
-    return new RSocketClientChannel(mono, new ServiceMessageCodec(headersCodec, dataCodecs));
+    return new RSocketClientChannel(
+        mono, new ServiceMessageCodec(headersCodec, dataCodecs), maxMessageSize);
   }
 
   private String selectServiceRole(ServiceReference serviceReference) {
@@ -98,8 +134,16 @@ public class RSocketClientTransport implements ClientTransport {
       Destination destination,
       ServiceReference serviceReference,
       Map<Destination, Mono<RSocket>> monoMap) {
-    return RSocketConnector.create()
-        .setupPayload(Mono.defer(() -> getCredentials(destination, serviceReference)))
+    final var connector =
+        RSocketConnector.create()
+            .setupPayload(Mono.defer(() -> getCredentials(destination, serviceReference)));
+    if (mtu > 0) {
+      connector.fragment(mtu);
+    }
+    if (maxMessageSize >= MAX_FRAME_LENGTH) {
+      connector.maxInboundPayloadSize(maxMessageSize);
+    }
+    return connector
         .connect(() -> clientTransportFactory.clientTransport(destination.address()))
         .doOnSuccess(
             rsocket -> {

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketClientTransport.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketClientTransport.java
@@ -27,10 +27,6 @@ public class RSocketClientTransport implements ClientTransport {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RSocketClientTransport.class);
 
-  // RSocket 24-bit frame-length cap. maxInboundPayloadSize must be >= this (a reassembly buffer must
-  // hold at least one full frame), so the inbound cap is only meaningful when the watermark is >= it.
-  private static final int MAX_FRAME_LENGTH = 0xFFFFFF;
-
   private final Map<Destination, Mono<RSocket>> rsockets = new ConcurrentHashMap<>();
 
   private final HeadersCodec headersCodec;
@@ -140,7 +136,7 @@ public class RSocketClientTransport implements ClientTransport {
     if (mtu > 0) {
       connector.fragment(mtu);
     }
-    if (maxMessageSize >= MAX_FRAME_LENGTH) {
+    if (maxMessageSize >= RSocketConstants.MAX_FRAME_LENGTH) {
       connector.maxInboundPayloadSize(maxMessageSize);
     }
     return connector

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketConstants.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketConstants.java
@@ -1,0 +1,19 @@
+package io.scalecube.services.transport.rsocket;
+
+/** RSocket protocol constants shared across the transport. */
+final class RSocketConstants {
+
+  /**
+   * RSocket single-frame cap: the frame-length header is 24 bits, so no single (non-fragmented)
+   * frame can exceed {@code 2^24 - 1} bytes. {@code maxInboundPayloadSize} must be at least this (a
+   * reassembly buffer must hold one full frame).
+   */
+  static final int MAX_FRAME_LENGTH = 0xFFFFFF; // 16_777_215
+
+  /** RSocket minimum fragmentation MTU. */
+  static final int MIN_MTU = 64;
+
+  private RSocketConstants() {
+    // do not instantiate
+  }
+}

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketImpl.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketImpl.java
@@ -74,7 +74,7 @@ public class RSocketImpl implements RSocket {
                               .doOnNext(response -> releaseOnError(message, response))
                               .contextWrite(requestContext(message)));
             })
-        .handle(this::encodeStreamPayload)
+        .transform(this::encodeStream)
         .doOnError(ex -> LOGGER.error("[requestStream] Exception occurred", ex));
   }
 
@@ -96,7 +96,7 @@ public class RSocketImpl implements RSocket {
               }
               return messages;
             })
-        .handle(this::encodeStreamPayload)
+        .transform(this::encodeStream)
         .doOnError(ex -> LOGGER.error("[requestChannel] Exception occurred", ex));
   }
 
@@ -134,6 +134,17 @@ public class RSocketImpl implements RSocket {
     } catch (MessageTooLargeException ex) {
       return toErrorPayload(response, ex);
     }
+  }
+
+  /**
+   * Stream encoder. With no watermark this is a plain {@code map} — identical to the prior behavior,
+   * so existing streaming calls are unaffected. Only when a watermark is set does it switch to {@code
+   * handle}, so an oversized element can terminate the stream with a {@code 413}.
+   */
+  private Flux<Payload> encodeStream(Flux<ServiceMessage> responses) {
+    return maxMessageSize > 0
+        ? responses.handle(this::encodeStreamPayload)
+        : responses.map(this::toPayload);
   }
 
   /**

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketImpl.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketImpl.java
@@ -8,6 +8,7 @@ import io.rsocket.util.ByteBufPayload;
 import io.scalecube.services.RequestContext;
 import io.scalecube.services.api.ServiceMessage;
 import io.scalecube.services.auth.Principal;
+import io.scalecube.services.exceptions.DefaultErrorMapper;
 import io.scalecube.services.exceptions.ServiceUnavailableException;
 import io.scalecube.services.methods.ServiceMethodInvoker;
 import io.scalecube.services.registry.api.ServiceRegistry;
@@ -24,12 +25,22 @@ public class RSocketImpl implements RSocket {
   private final Principal principal;
   private final ServiceMessageCodec messageCodec;
   private final ServiceRegistry serviceRegistry;
+  private final int maxMessageSize;
 
   public RSocketImpl(
       Principal principal, ServiceMessageCodec messageCodec, ServiceRegistry serviceRegistry) {
+    this(principal, messageCodec, serviceRegistry, 0);
+  }
+
+  public RSocketImpl(
+      Principal principal,
+      ServiceMessageCodec messageCodec,
+      ServiceRegistry serviceRegistry,
+      int maxMessageSize) {
     this.principal = principal;
     this.messageCodec = messageCodec;
     this.serviceRegistry = serviceRegistry;
+    this.maxMessageSize = maxMessageSize;
   }
 
   @Override
@@ -101,7 +112,15 @@ public class RSocketImpl implements RSocket {
   }
 
   private Payload toPayload(ServiceMessage response) {
-    return messageCodec.encodeAndTransform(response, ByteBufPayload::create);
+    try {
+      return messageCodec.encodeAndTransform(response, maxMessageSize, ByteBufPayload::create);
+    } catch (MessageTooLargeException ex) {
+      // The streaming encoder aborted because the response crossed the watermark: fail fast with a
+      // business error (413) instead of attempting to frame/fragment it. The oversized payload was
+      // never fully materialized, so this cannot OOM the responder.
+      final var errorMessage = DefaultErrorMapper.INSTANCE.toMessage(response.qualifier(), ex);
+      return messageCodec.encodeAndTransform(errorMessage, ByteBufPayload::create);
+    }
   }
 
   private ServiceMessage toMessage(Payload payload) {

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketImpl.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketImpl.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.SynchronousSink;
 
 public class RSocketImpl implements RSocket {
 
@@ -56,7 +57,7 @@ public class RSocketImpl implements RSocket {
                               .doOnNext(response -> releaseOnError(message, response))
                               .contextWrite(requestContext(message)));
             })
-        .map(this::toPayload)
+        .map(this::toResponsePayload)
         .doOnError(ex -> LOGGER.error("[requestResponse] Exception occurred", ex));
   }
 
@@ -73,7 +74,7 @@ public class RSocketImpl implements RSocket {
                               .doOnNext(response -> releaseOnError(message, response))
                               .contextWrite(requestContext(message)));
             })
-        .map(this::toPayload)
+        .handle(this::encodeStreamPayload)
         .doOnError(ex -> LOGGER.error("[requestStream] Exception occurred", ex));
   }
 
@@ -95,7 +96,7 @@ public class RSocketImpl implements RSocket {
               }
               return messages;
             })
-        .map(this::toPayload)
+        .handle(this::encodeStreamPayload)
         .doOnError(ex -> LOGGER.error("[requestChannel] Exception occurred", ex));
   }
 
@@ -111,15 +112,41 @@ public class RSocketImpl implements RSocket {
         .doOnError(ex -> safestRelease(message.data()));
   }
 
+  /** Encodes a response payload; throws {@link MessageTooLargeException} if it crosses the limit. */
   private Payload toPayload(ServiceMessage response) {
+    return messageCodec.encodeAndTransform(response, maxMessageSize, ByteBufPayload::create);
+  }
+
+  /**
+   * Builds a {@code 413} business-error payload for a response that exceeded the limit. The
+   * oversized payload was never fully materialized (the streaming encoder aborted), so this cannot
+   * OOM the responder.
+   */
+  private Payload toErrorPayload(ServiceMessage response, MessageTooLargeException ex) {
+    final var errorMessage = DefaultErrorMapper.INSTANCE.toMessage(response.qualifier(), ex);
+    return messageCodec.encodeAndTransform(errorMessage, ByteBufPayload::create);
+  }
+
+  /** request-response: an oversized response becomes the single {@code 413} reply. */
+  private Payload toResponsePayload(ServiceMessage response) {
     try {
-      return messageCodec.encodeAndTransform(response, maxMessageSize, ByteBufPayload::create);
+      return toPayload(response);
     } catch (MessageTooLargeException ex) {
-      // The streaming encoder aborted because the response crossed the watermark: fail fast with a
-      // business error (413) instead of attempting to frame/fragment it. The oversized payload was
-      // never fully materialized, so this cannot OOM the responder.
-      final var errorMessage = DefaultErrorMapper.INSTANCE.toMessage(response.qualifier(), ex);
-      return messageCodec.encodeAndTransform(errorMessage, ByteBufPayload::create);
+      return toErrorPayload(response, ex);
+    }
+  }
+
+  /**
+   * request-stream / request-channel: an oversized element terminates the stream with a {@code 413}
+   * — the error is emitted and the stream is completed, so the responder stops producing instead of
+   * encoding and sending the remaining elements.
+   */
+  private void encodeStreamPayload(ServiceMessage response, SynchronousSink<Payload> sink) {
+    try {
+      sink.next(toPayload(response));
+    } catch (MessageTooLargeException ex) {
+      sink.next(toErrorPayload(response, ex));
+      sink.complete();
     }
   }
 

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServerTransport.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServerTransport.java
@@ -16,10 +16,6 @@ public class RSocketServerTransport implements ServerTransport {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RSocketServerTransport.class);
 
-  // RSocket 24-bit frame-length cap. maxInboundPayloadSize must be >= this (a reassembly buffer must
-  // hold at least one full frame), so the inbound cap is only meaningful when the watermark is >= it.
-  private static final int MAX_FRAME_LENGTH = 0xFFFFFF;
-
   private final Authenticator authenticator;
   private final ServiceRegistry serviceRegistry;
   private final HeadersCodec headersCodec;
@@ -99,7 +95,7 @@ public class RSocketServerTransport implements ServerTransport {
       if (mtu > 0) {
         rsocketServer.fragment(mtu);
       }
-      if (maxMessageSize >= MAX_FRAME_LENGTH) {
+      if (maxMessageSize >= RSocketConstants.MAX_FRAME_LENGTH) {
         rsocketServer.maxInboundPayloadSize(maxMessageSize);
       }
       serverChannel =

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServerTransport.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServerTransport.java
@@ -16,16 +16,22 @@ public class RSocketServerTransport implements ServerTransport {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RSocketServerTransport.class);
 
+  // RSocket 24-bit frame-length cap. maxInboundPayloadSize must be >= this (a reassembly buffer must
+  // hold at least one full frame), so the inbound cap is only meaningful when the watermark is >= it.
+  private static final int MAX_FRAME_LENGTH = 0xFFFFFF;
+
   private final Authenticator authenticator;
   private final ServiceRegistry serviceRegistry;
   private final HeadersCodec headersCodec;
   private final Collection<DataCodec> dataCodecs;
   private final RSocketServerTransportFactory serverTransportFactory;
+  private final int mtu;
+  private final int maxMessageSize;
 
   private CloseableChannel serverChannel; // calculated
 
   /**
-   * Constructor for this server transport.
+   * Constructor for this server transport. Fragmentation is disabled and message size is unbounded.
    *
    * @param authenticator authenticator
    * @param serviceRegistry serviceRegistry
@@ -39,11 +45,40 @@ public class RSocketServerTransport implements ServerTransport {
       HeadersCodec headersCodec,
       Collection<DataCodec> dataCodecs,
       RSocketServerTransportFactory serverTransportFactory) {
+    this(authenticator, serviceRegistry, headersCodec, dataCodecs, serverTransportFactory, 0, 0);
+  }
+
+  /**
+   * Constructor for this server transport.
+   *
+   * @param authenticator authenticator
+   * @param serviceRegistry serviceRegistry
+   * @param headersCodec headersCodec
+   * @param dataCodecs dataCodecs
+   * @param serverTransportFactory serverTransportFactory
+   * @param mtu fragmentation MTU in bytes; {@code 0} disables fragmentation (see {@link
+   *     io.rsocket.core.RSocketServer#fragment(int)})
+   * @param maxMessageSize maximum message size in bytes; {@code 0} means unbounded. Bounds both the
+   *     encoded response size (responses larger than this fail fast with {@link
+   *     MessageTooLargeException} instead of being framed) and inbound reassembly (see {@link
+   *     io.rsocket.core.RSocketServer#maxInboundPayloadSize(int)}), preventing OOM in either
+   *     direction.
+   */
+  public RSocketServerTransport(
+      Authenticator authenticator,
+      ServiceRegistry serviceRegistry,
+      HeadersCodec headersCodec,
+      Collection<DataCodec> dataCodecs,
+      RSocketServerTransportFactory serverTransportFactory,
+      int mtu,
+      int maxMessageSize) {
     this.authenticator = authenticator;
     this.serviceRegistry = serviceRegistry;
     this.headersCodec = headersCodec;
     this.dataCodecs = dataCodecs;
     this.serverTransportFactory = serverTransportFactory;
+    this.mtu = mtu;
+    this.maxMessageSize = maxMessageSize;
   }
 
   @Override
@@ -56,14 +91,19 @@ public class RSocketServerTransport implements ServerTransport {
   @Override
   public ServerTransport bind() {
     try {
-      serverChannel =
+      final var rsocketServer =
           RSocketServer.create()
               .acceptor(
                   new RSocketServiceAcceptor(
-                      headersCodec, dataCodecs, authenticator, serviceRegistry))
-              .bind(serverTransportFactory.serverTransport())
-              .toFuture()
-              .get();
+                      headersCodec, dataCodecs, authenticator, serviceRegistry, maxMessageSize));
+      if (mtu > 0) {
+        rsocketServer.fragment(mtu);
+      }
+      if (maxMessageSize >= MAX_FRAME_LENGTH) {
+        rsocketServer.maxInboundPayloadSize(maxMessageSize);
+      }
+      serverChannel =
+          rsocketServer.bind(serverTransportFactory.serverTransport()).toFuture().get();
       return this;
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServiceAcceptor.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServiceAcceptor.java
@@ -25,16 +25,27 @@ public class RSocketServiceAcceptor implements SocketAcceptor {
   private final Collection<DataCodec> dataCodecs;
   private final Authenticator authenticator;
   private final ServiceRegistry serviceRegistry;
+  private final int maxMessageSize;
 
   public RSocketServiceAcceptor(
       HeadersCodec headersCodec,
       Collection<DataCodec> dataCodecs,
       Authenticator authenticator,
       ServiceRegistry serviceRegistry) {
+    this(headersCodec, dataCodecs, authenticator, serviceRegistry, 0);
+  }
+
+  public RSocketServiceAcceptor(
+      HeadersCodec headersCodec,
+      Collection<DataCodec> dataCodecs,
+      Authenticator authenticator,
+      ServiceRegistry serviceRegistry,
+      int maxMessageSize) {
     this.headersCodec = headersCodec;
     this.dataCodecs = dataCodecs;
     this.authenticator = authenticator;
     this.serviceRegistry = serviceRegistry;
+    this.maxMessageSize = maxMessageSize;
   }
 
   @Override
@@ -59,6 +70,6 @@ public class RSocketServiceAcceptor implements SocketAcceptor {
 
   private RSocket newRSocket(Principal principal) {
     return new RSocketImpl(
-        principal, new ServiceMessageCodec(headersCodec, dataCodecs), serviceRegistry);
+        principal, new ServiceMessageCodec(headersCodec, dataCodecs), serviceRegistry, maxMessageSize);
   }
 }

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServiceTransport.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServiceTransport.java
@@ -45,6 +45,8 @@ public class RSocketServiceTransport implements ServiceTransport {
   private CredentialsSupplier credentialsSupplier;
   private Authenticator authenticator;
   private Collection<String> allowedRoles;
+  private int mtu = 0;
+  private int maxMessageSize = 0;
 
   private Function<LoopResources, RSocketServerTransportFactory> serverTransportFactory =
       RSocketServerTransportFactory.websocket();
@@ -76,6 +78,8 @@ public class RSocketServiceTransport implements ServiceTransport {
     this.serverTransportFactory = other.serverTransportFactory;
     this.clientTransportFactory = other.clientTransportFactory;
     this.allowedRoles = other.allowedRoles;
+    this.mtu = other.mtu;
+    this.maxMessageSize = other.maxMessageSize;
   }
 
   /**
@@ -176,6 +180,42 @@ public class RSocketServiceTransport implements ServiceTransport {
     return rst;
   }
 
+  /**
+   * Setter for {@code mtu} (fragmentation MTU, in bytes). RSocket frames larger than this are
+   * fragmented on send and reassembled on receive; {@code 0} (the default) disables fragmentation.
+   * Set it below the RSocket single-frame cap ({@code 2^24 - 1} bytes) to allow payloads larger
+   * than a single frame. Applies to both the client and server transports.
+   *
+   * @param mtu fragmentation MTU in bytes ({@code 0} disables fragmentation)
+   * @return new {@link RSocketServiceTransport} instance
+   */
+  public RSocketServiceTransport mtu(int mtu) {
+    RSocketServiceTransport rst = new RSocketServiceTransport(this);
+    rst.mtu = mtu;
+    return rst;
+  }
+
+  /**
+   * Setter for {@code maxMessageSize} (the high-watermark, in bytes). When {@code > 0}, this is the
+   * maximum size of a single encoded message: an outbound message larger than this fails fast while
+   * encoding with a {@code 413} service error (never framed, fragmented, or fully buffered),
+   * preventing OOM on the sender. When it is also {@code >=} the single-frame cap ({@code 2^24 - 1}),
+   * inbound reassembly is additionally capped at the same size (see {@link
+   * io.rsocket.core.RSocketServer#maxInboundPayloadSize(int)}), preventing OOM on the receiver; RSocket
+   * forbids an inbound cap below the frame size (a single frame must always fit), so a watermark below
+   * the frame cap bounds only the outbound encode. {@code 0} (the default) means unbounded. Set it
+   * above the single-frame cap and pair it with {@link #mtu(int)} to allow legitimately large
+   * (fragmented) responses up to the watermark while still rejecting anything beyond it.
+   *
+   * @param maxMessageSize maximum message size in bytes ({@code 0} means unbounded)
+   * @return new {@link RSocketServiceTransport} instance
+   */
+  public RSocketServiceTransport maxMessageSize(int maxMessageSize) {
+    RSocketServiceTransport rst = new RSocketServiceTransport(this);
+    rst.maxMessageSize = maxMessageSize;
+    return rst;
+  }
+
   @Override
   public ClientTransport clientTransport() {
     return new RSocketClientTransport(
@@ -183,7 +223,9 @@ public class RSocketServiceTransport implements ServiceTransport {
         dataCodecs,
         clientTransportFactory.apply(clientLoopResources),
         credentialsSupplier,
-        allowedRoles);
+        allowedRoles,
+        mtu,
+        maxMessageSize);
   }
 
   @Override
@@ -193,7 +235,9 @@ public class RSocketServiceTransport implements ServiceTransport {
         serviceRegistry,
         headersCodec,
         dataCodecs,
-        serverTransportFactory.apply(serverLoopResources));
+        serverTransportFactory.apply(serverLoopResources),
+        mtu,
+        maxMessageSize);
   }
 
   @Override

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServiceTransport.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServiceTransport.java
@@ -183,13 +183,25 @@ public class RSocketServiceTransport implements ServiceTransport {
   /**
    * Setter for {@code mtu} (fragmentation MTU, in bytes). RSocket frames larger than this are
    * fragmented on send and reassembled on receive; {@code 0} (the default) disables fragmentation.
-   * Set it below the RSocket single-frame cap ({@code 2^24 - 1} bytes) to allow payloads larger
-   * than a single frame. Applies to both the client and server transports.
+   * Applies to both the client and server transports. A non-zero value must be in {@code [64,
+   * 2^24-1)} (RSocket's minimum fragment size, and below the single-frame cap); other values are
+   * rejected up front rather than failing deep inside RSocket at bind/connect.
    *
-   * @param mtu fragmentation MTU in bytes ({@code 0} disables fragmentation)
+   * @param mtu fragmentation MTU in bytes ({@code 0} disables fragmentation, otherwise {@code [64,
+   *     2^24-1)})
    * @return new {@link RSocketServiceTransport} instance
+   * @throws IllegalArgumentException if {@code mtu} is non-zero and outside {@code [64, 2^24-1)}
    */
   public RSocketServiceTransport mtu(int mtu) {
+    if (mtu != 0 && (mtu < RSocketConstants.MIN_MTU || mtu >= RSocketConstants.MAX_FRAME_LENGTH)) {
+      throw new IllegalArgumentException(
+          "mtu must be 0 or in ["
+              + RSocketConstants.MIN_MTU
+              + ", "
+              + RSocketConstants.MAX_FRAME_LENGTH
+              + "): "
+              + mtu);
+    }
     RSocketServiceTransport rst = new RSocketServiceTransport(this);
     rst.mtu = mtu;
     return rst;
@@ -205,14 +217,27 @@ public class RSocketServiceTransport implements ServiceTransport {
    * inbound reassembly is additionally capped at the same size (see {@link
    * io.rsocket.core.RSocketServer#maxInboundPayloadSize(int)}), preventing OOM on the receiver; RSocket
    * forbids an inbound cap below the frame size (a single frame must always fit), so a watermark below
-   * the frame cap bounds only the outbound encode. {@code 0} (the default) means unbounded. Set it
-   * above the single-frame cap and pair it with {@link #mtu(int)} to allow legitimately large
-   * (fragmented) responses up to the watermark while still rejecting anything beyond it.
+   * the frame cap bounds only the outbound encode (so to cap what you <em>receive</em>, the value
+   * must be {@code >=} the frame cap). {@code 0} (the default) means unbounded. Set it above the
+   * single-frame cap and pair it with {@link #mtu(int)} to allow legitimately large (fragmented)
+   * responses up to the watermark while still rejecting anything beyond it.
+   *
+   * <p>Two caveats. (1) Because the limit counts only the encoded data, a value near the frame cap
+   * <em>without</em> {@link #mtu(int)} can still overflow the real single-frame limit (data +
+   * headers + framing) and surface the cryptic RSocket {@code CanceledException} this is meant to
+   * replace; to use it as a {@code CanceledException} replacement without fragmentation, keep it
+   * safely below the frame cap. (2) The {@code 413} does not surface as an error on {@code
+   * byte[]}-typed service methods (the client decodes a {@code byte[]} response before checking the
+   * error flag) until that separate fix lands.
    *
    * @param maxMessageSize maximum message size in bytes ({@code 0} means unbounded)
    * @return new {@link RSocketServiceTransport} instance
+   * @throws IllegalArgumentException if {@code maxMessageSize} is negative
    */
   public RSocketServiceTransport maxMessageSize(int maxMessageSize) {
+    if (maxMessageSize < 0) {
+      throw new IllegalArgumentException("maxMessageSize must be >= 0: " + maxMessageSize);
+    }
     RSocketServiceTransport rst = new RSocketServiceTransport(this);
     rst.maxMessageSize = maxMessageSize;
     return rst;

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServiceTransport.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/RSocketServiceTransport.java
@@ -196,10 +196,12 @@ public class RSocketServiceTransport implements ServiceTransport {
   }
 
   /**
-   * Setter for {@code maxMessageSize} (the high-watermark, in bytes). When {@code > 0}, this is the
-   * maximum size of a single encoded message: an outbound message larger than this fails fast while
-   * encoding with a {@code 413} service error (never framed, fragmented, or fully buffered),
-   * preventing OOM on the sender. When it is also {@code >=} the single-frame cap ({@code 2^24 - 1}),
+   * Setter for {@code maxMessageSize} (the high-watermark, in bytes). When {@code > 0}, this bounds
+   * the encoded <em>data</em> payload of a single message (the message's headers/metadata are not
+   * counted toward the limit, so the full on-wire payload is slightly larger): an outbound message
+   * whose encoded data exceeds this fails fast while encoding with a {@code 413} service error
+   * (never framed, fragmented, or fully buffered), preventing OOM on the sender. When it is also
+   * {@code >=} the single-frame cap ({@code 2^24 - 1}),
    * inbound reassembly is additionally capped at the same size (see {@link
    * io.rsocket.core.RSocketServer#maxInboundPayloadSize(int)}), preventing OOM on the receiver; RSocket
    * forbids an inbound cap below the frame size (a single frame must always fit), so a watermark below

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/ServiceMessageCodec.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/ServiceMessageCodec.java
@@ -115,14 +115,12 @@ public final class ServiceMessageCodec {
       dataBuffer = message.data();
       if (maxMessageSize > 0 && dataBuffer.readableBytes() > maxMessageSize) {
         safestRelease(dataBuffer);
-        throw new MessageTooLargeException(
-            "Message size exceeds limit (" + maxMessageSize + " bytes)");
+        throw MessageTooLargeException.of(maxMessageSize);
       }
     } else if (message.hasData(byte[].class)) {
       final var bytes = (byte[]) message.data();
       if (maxMessageSize > 0 && bytes.length > maxMessageSize) {
-        throw new MessageTooLargeException(
-            "Message size exceeds limit (" + maxMessageSize + " bytes)");
+        throw MessageTooLargeException.of(maxMessageSize);
       }
       dataBuffer = bufAllocator.buffer(bytes.length);
       dataBuffer.writeBytes(bytes);

--- a/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/ServiceMessageCodec.java
+++ b/services-transport-parent/services-transport-rsocket/src/main/java/io/scalecube/services/transport/rsocket/ServiceMessageCodec.java
@@ -16,6 +16,7 @@ import io.scalecube.services.exceptions.MessageCodecException;
 import io.scalecube.services.transport.api.DataCodec;
 import io.scalecube.services.transport.api.HeadersCodec;
 import io.scalecube.services.transport.api.JdkCodec;
+import java.io.OutputStream;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Collections;
@@ -87,23 +88,59 @@ public final class ServiceMessageCodec {
   public <T> T encodeAndTransform(
       ServiceMessage message, BiFunction<ByteBuf, ByteBuf, T> transformer)
       throws MessageCodecException {
+    return encodeAndTransform(message, 0, transformer);
+  }
+
+  /**
+   * Encode a message, transform it to T, bounding the encoded data size.
+   *
+   * @param message the message to transform
+   * @param maxMessageSize maximum encoded data size in bytes; when {@code > 0}, encoding aborts with
+   *     {@link MessageTooLargeException} as soon as it would exceed this size (so an oversized
+   *     message is never fully materialized), {@code 0} means unbounded
+   * @param transformer a function that accepts data and header {@link ByteBuf} and return the
+   *     required T
+   * @return the object (transformed message)
+   * @throws MessageTooLargeException when the encoded data would exceed {@code maxMessageSize}
+   * @throws MessageCodecException when encoding cannot be done.
+   */
+  public <T> T encodeAndTransform(
+      ServiceMessage message, int maxMessageSize, BiFunction<ByteBuf, ByteBuf, T> transformer)
+      throws MessageCodecException {
     final var bufAllocator = ByteBufAllocator.DEFAULT;
     ByteBuf dataBuffer = Unpooled.EMPTY_BUFFER;
     ByteBuf headersBuffer = Unpooled.EMPTY_BUFFER;
 
     if (message.hasData(ByteBuf.class)) {
       dataBuffer = message.data();
+      if (maxMessageSize > 0 && dataBuffer.readableBytes() > maxMessageSize) {
+        safestRelease(dataBuffer);
+        throw new MessageTooLargeException(
+            "Message size exceeds limit (" + maxMessageSize + " bytes)");
+      }
     } else if (message.hasData(byte[].class)) {
       final var bytes = (byte[]) message.data();
+      if (maxMessageSize > 0 && bytes.length > maxMessageSize) {
+        throw new MessageTooLargeException(
+            "Message size exceeds limit (" + maxMessageSize + " bytes)");
+      }
       dataBuffer = bufAllocator.buffer(bytes.length);
       dataBuffer.writeBytes(bytes);
     } else if (message.hasData()) {
       dataBuffer = bufAllocator.buffer();
       try {
         DataCodec dataCodec = getDataCodec(message.dataFormatOrDefault());
-        dataCodec.encode(new ByteBufOutputStream(dataBuffer), message.data());
+        OutputStream outputStream = new ByteBufOutputStream(dataBuffer);
+        if (maxMessageSize > 0) {
+          outputStream = new LimitedOutputStream(outputStream, maxMessageSize);
+        }
+        dataCodec.encode(outputStream, message.data());
       } catch (Throwable ex) {
         safestRelease(dataBuffer);
+        final var tooLarge = findTooLarge(ex);
+        if (tooLarge != null) {
+          throw tooLarge;
+        }
         LOGGER.error(
             "Failed to encode service message data on: {}, cause: {}", message, ex.toString());
         throw new MessageCodecException("Failed to encode service message data", ex);
@@ -199,5 +236,17 @@ public final class ServiceMessageCodec {
     Objects.requireNonNull(contentType, "contentType");
     DataCodec dataCodec = dataCodecs.get(contentType);
     return Objects.requireNonNull(dataCodec, "dataCodec");
+  }
+
+  private static MessageTooLargeException findTooLarge(Throwable ex) {
+    for (Throwable t = ex; t != null; t = t.getCause()) {
+      if (t instanceof MessageTooLargeException tooLarge) {
+        return tooLarge;
+      }
+      if (t.getCause() == t) {
+        break;
+      }
+    }
+    return null;
   }
 }

--- a/services-transport-parent/services-transport-rsocket/src/test/java/io/scalecube/services/transport/rsocket/LimitedOutputStreamTest.java
+++ b/services-transport-parent/services-transport-rsocket/src/test/java/io/scalecube/services/transport/rsocket/LimitedOutputStreamTest.java
@@ -1,0 +1,92 @@
+package io.scalecube.services.transport.rsocket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit spec for {@link LimitedOutputStream} — the streaming guard that makes the maximum-message-size
+ * watermark <em>OOM-safe</em>.
+ *
+ * <p>The key property is that the check happens <b>on the fly</b>, per write, <em>before</em> the
+ * bytes reach the underlying buffer: as soon as the running total would cross the limit the stream
+ * throws {@link MessageTooLargeException}, so an oversized message is aborted mid-encode and is
+ * never fully materialized. These tests pin exactly that — including that no byte past the limit is
+ * ever handed to the delegate.
+ */
+class LimitedOutputStreamTest {
+
+  @Test
+  @DisplayName("writing exactly the limit is allowed and reaches the delegate")
+  void allowsExactlyTheLimit() throws IOException {
+    final var sink = new ByteArrayOutputStream();
+    try (var out = new LimitedOutputStream(sink, 4)) {
+      out.write(new byte[] {1, 2, 3, 4}); // exactly the limit
+    }
+    assertEquals(4, sink.size());
+  }
+
+  @Test
+  @DisplayName("a bulk write that would overflow throws and writes nothing")
+  void bulkWriteThatOverflowsThrowsBeforeWriting() {
+    final var sink = new ByteArrayOutputStream();
+    final var out = new LimitedOutputStream(sink, 4);
+
+    final var ex =
+        assertThrows(
+            MessageTooLargeException.class, () -> out.write(new byte[] {1, 2, 3, 4, 5}));
+
+    assertEquals(0, sink.size(), "no bytes may reach the delegate when the chunk would overflow");
+    assertEquals(413, ex.errorCode(), "errorCode");
+    assertTrue(ex.getMessage().contains("exceeds limit (4 bytes)"), ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("single-byte writes abort on the very byte that crosses the limit")
+  void singleByteWriteAbortsOnCrossing() throws IOException {
+    final var sink = new ByteArrayOutputStream();
+    final var out = new LimitedOutputStream(sink, 3);
+
+    out.write(1);
+    out.write(2);
+    out.write(3); // fills the limit exactly
+
+    assertThrows(MessageTooLargeException.class, () -> out.write(4)); // the crossing byte
+    assertEquals(3, sink.size(), "only limit bytes reached the delegate");
+  }
+
+  @Test
+  @DisplayName("streaming a would-be huge payload never buffers more than the limit (OOM-safe)")
+  void neverMaterializesMoreThanTheLimit() {
+    // Simulate a serializer streaming an enormous object in chunks. Unbounded this would buffer
+    // 8 GiB; the limiter must stop it after at most `limit` bytes.
+    final int limit = 64 * 1024; // 64 KiB
+    final var sink = new ByteArrayOutputStream();
+    final var out = new LimitedOutputStream(sink, limit);
+    final var chunk = new byte[8 * 1024]; // 8 KiB chunks
+
+    assertThrows(
+        MessageTooLargeException.class,
+        () -> {
+          for (int i = 0; i < 1024 * 1024; i++) { // would be 8 GiB if unbounded
+            out.write(chunk);
+          }
+        });
+
+    assertTrue(sink.size() <= limit, "buffered bytes must never exceed the limit, was " + sink.size());
+  }
+
+  @Test
+  @DisplayName("limit of 0 via this stream means 'no bytes allowed' (callers pass >0 to enable)")
+  void zeroLimitRejectsAnyWrite() {
+    // Note: the transport only constructs a LimitedOutputStream when maxMessageSize > 0; this just
+    // documents the boundary behavior of the stream itself.
+    final var out = new LimitedOutputStream(new ByteArrayOutputStream(), 0);
+    assertThrows(MessageTooLargeException.class, () -> out.write(1));
+  }
+}

--- a/services/src/test/java/io/scalecube/services/RSocketLargePayloadTest.java
+++ b/services/src/test/java/io/scalecube/services/RSocketLargePayloadTest.java
@@ -1,0 +1,377 @@
+package io.scalecube.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.scalecube.services.Microservices.Context;
+import io.scalecube.services.annotations.Service;
+import io.scalecube.services.annotations.ServiceMethod;
+import io.scalecube.services.exceptions.ServiceException;
+import io.scalecube.services.routing.StaticAddressRouter;
+import io.scalecube.services.transport.api.DataCodec;
+import io.scalecube.services.transport.api.HeadersCodec;
+import io.scalecube.services.transport.rsocket.RSocketClientTransport;
+import io.scalecube.services.transport.rsocket.RSocketClientTransportFactory;
+import io.scalecube.services.transport.rsocket.RSocketServiceTransport;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.netty.resources.LoopResources;
+import reactor.test.StepVerifier;
+
+/**
+ * Executable spec for the RSocket transport's large-payload handling, modeled on a production
+ * incident where a service returned an unbounded result set as a single RSocket response. It
+ * documents, as runnable cases, what happens for every payload size under every configuration.
+ *
+ * <h2>The two RSocket limits</h2>
+ *
+ * <ul>
+ *   <li><b>Single-frame cap</b> — {@value #MAX_FRAME_LENGTH} bytes ({@code 2^24 - 1}). RSocket's
+ *       frame-length header is 24 bits, so no single (non-fragmented) frame can be larger. Fixed by
+ *       the protocol; it cannot be raised. This is the only limit these tests must use a real
+ *       ~16&nbsp;MB payload to exercise.
+ *   <li><b>Reassembly cap</b> — {@code maxInboundPayloadSize} (default ~2&nbsp;GiB, minimum 64&nbsp;B).
+ *       With fragmentation on, a payload is split into frames and reassembled on the receiver up to
+ *       this size.
+ * </ul>
+ *
+ * <h2>The transport knobs (on {@link RSocketServiceTransport})</h2>
+ *
+ * <ul>
+ *   <li>{@link RSocketServiceTransport#mtu(int) mtu} — enable fragmentation so a payload larger than
+ *       the single-frame cap can be sent in pieces.
+ *   <li>{@link RSocketServiceTransport#maxMessageSize(int) maxMessageSize} — the high-watermark. It
+ *       (a) bounds outbound encoding via a <em>streaming</em> guard that aborts the instant the byte
+ *       count crosses the limit — so an oversized message is never fully materialized and cannot OOM
+ *       the encoder — surfacing a clean {@code 413} business error; and (b) caps inbound reassembly
+ *       on both ends so a peer cannot OOM the receiver either.
+ * </ul>
+ *
+ * <p>Only the single-frame-cap is a fixed ~16&nbsp;MB protocol constant, so only {@link
+ * #responseOverFrameCapFailsWithoutFragmentation()} and {@link #responseOverFrameCapIsFragmented()}
+ * use a large payload. Every other guarantee is proven at KB scale (and the streaming/OOM-safety of
+ * the encoder itself is proven separately, allocation-free, in {@code LimitedOutputStreamTest}).
+ * Fragmentation and the watermark compose: to allow legitimately large (fragmented) responses while
+ * rejecting anything beyond a ceiling, set {@code maxMessageSize} above the frame cap and pair it
+ * with {@code mtu}.
+ *
+ * <p><b>Honest scope:</b> these knobs bound serialization and reassembly. They cannot stop a service
+ * from OOMing while building its own result objects before encoding — that requires bounding the
+ * query (pagination/streaming) at the service. {@link #streamSucceeds()} shows that shape.
+ */
+final class RSocketLargePayloadTest {
+
+  private static final Duration TIMEOUT = Duration.ofSeconds(30);
+  private static final LoopResources LOOP_RESOURCE = LoopResources.create("large-payload-test");
+
+  /** RSocket frame length is a 24-bit field: max single-frame payload is {@code 2^24 - 1}. */
+  private static final int MAX_FRAME_LENGTH = 0xFFFFFF; // 16_777_215
+
+  /** Just over the single-frame cap — the smallest payload that needs fragmentation. */
+  private static final int OVER_FRAME_CAP = MAX_FRAME_LENGTH + 1;
+
+  private static final int FRAGMENT_MTU = 1024 * 1024; // 1 MiB, for the frame-cap fragmentation test
+  private static final int WATERMARK = 8 * 1024; // 8 KiB high-watermark for the KB-scale cases
+
+  private Microservices service;
+  private ServiceCall serviceCall;
+
+  @AfterEach
+  void afterEach() {
+    if (serviceCall != null) {
+      serviceCall.close();
+    }
+    if (service != null) {
+      service.close();
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // single-frame cap (the fixed ~16 MB protocol constant) — the only large-payload cases
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("default: a response within the single-frame cap is delivered")
+  void smallResponseSucceeds() {
+    final var api = payloadService(0, 0, 0);
+
+    final byte[] payload = api.getPayload(1024).block(TIMEOUT);
+    assertNotNull(payload);
+    assertEquals(1024, payload.length);
+  }
+
+  @Test
+  @DisplayName("default: a response over the single-frame cap fails with the RSocket frame error")
+  void responseOverFrameCapFailsWithoutFragmentation() {
+    final var api = payloadService(0, 0, 0);
+
+    StepVerifier.create(api.getPayload(OVER_FRAME_CAP))
+        .expectErrorSatisfies(
+            ex -> {
+              assertNotNull(ex.getMessage());
+              assertTrue(
+                  ex.getMessage().contains("too big to be send as a single frame"),
+                  "unexpected: " + ex);
+              assertTrue(
+                  ex.getMessage().contains(String.valueOf(MAX_FRAME_LENGTH)),
+                  "should state the 24-bit cap: " + ex);
+            })
+        .verify(TIMEOUT);
+  }
+
+  @Test
+  @DisplayName("fragment: a response over the single-frame cap is fragmented and delivered whole")
+  void responseOverFrameCapIsFragmented() {
+    final var api = payloadService(FRAGMENT_MTU, 0, 0);
+
+    final byte[] payload = api.getPayload(OVER_FRAME_CAP).block(TIMEOUT);
+    assertNotNull(payload);
+    assertEquals(OVER_FRAME_CAP, payload.length);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // watermark — business error beyond it (KB scale; no fragmentation needed to prove the point)
+  // ---------------------------------------------------------------------------------------------
+
+  // Note: these boundary cases use a String response (encoded data = length + 2 JSON quote bytes),
+  // not byte[]. A Mono<byte[]> method cannot be used here because ServiceMessageCodec.decodeData
+  // decodes a byte[]-typed response before checking isError(), so a byte[] client swallows error
+  // responses as raw bytes — a pre-existing scalecube quirk unrelated to the watermark.
+
+  @Test
+  @DisplayName("watermark: a response exactly at the watermark is allowed")
+  void responseExactlyAtWatermarkSucceeds() {
+    final var api = payloadService(0, WATERMARK, 0);
+
+    final String payload = api.getText(WATERMARK - 2).block(TIMEOUT); // encoded data == limit
+    assertNotNull(payload);
+    assertEquals(WATERMARK - 2, payload.length());
+  }
+
+  @Test
+  @DisplayName("watermark: one byte over the watermark fails fast with code 413 and the exact limit")
+  void responseOneByteOverWatermarkFailsFast() {
+    final var api = payloadService(0, WATERMARK, 0);
+
+    StepVerifier.create(api.getText(WATERMARK - 1)) // encoded data == watermark + 1
+        .expectErrorSatisfies(
+            ex -> {
+              final var se = assertInstanceOf(ServiceException.class, ex);
+              assertEquals(413, se.errorCode(), "errorCode");
+              assertEquals("Message size exceeds limit (" + WATERMARK + " bytes)", se.getMessage());
+            })
+        .verify(TIMEOUT);
+  }
+
+  @Test
+  @DisplayName("watermark: a realistic unbounded collection response is aborted mid-encode (413)")
+  void oversizedCollectionResponseFailsFast() {
+    final var api = payloadService(0, WATERMARK, 0);
+
+    // ~50 KB of JSON vs an 8 KB watermark: the streaming encoder aborts after ~8 KB, never building
+    // the whole array. Same shape as an unbounded "fetch everything" query, in miniature.
+    StepVerifier.create(api.getItems(50))
+        .expectErrorSatisfies(
+            ex -> {
+              final var se = assertInstanceOf(ServiceException.class, ex);
+              assertEquals(413, se.errorCode());
+              assertTrue(se.getMessage().contains("exceeds limit"), "unexpected: " + ex);
+            })
+        .verify(TIMEOUT);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // inbound reassembly cap — protects the receiver from a peer that ignores the watermark
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("inbound cap: a response larger than the client's reassembly cap is rejected")
+  void responseExceedingClientInboundCapIsRejected() {
+    // RSocket requires the inbound cap to be >= the single-frame cap, so the smallest meaningful cap
+    // is the frame cap itself. Server fragments freely with no watermark; the client caps reassembly
+    // at exactly the frame cap, and a payload one byte larger is rejected on reassembly.
+    final var api = payloadService(FRAGMENT_MTU, 0, MAX_FRAME_LENGTH);
+
+    StepVerifier.create(api.getPayload(OVER_FRAME_CAP)) // one byte over the client's reassembly cap
+        .expectError()
+        .verify(TIMEOUT);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // request side — the same guard protects the client from building an oversized request
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("request: an oversized request fails fast on the client, before the wire (413)")
+  void oversizedRequestFailsFastOnClient() {
+    final var api = payloadService(0, 0, WATERMARK);
+
+    StepVerifier.create(api.upload(new byte[WATERMARK + 1]))
+        .expectErrorSatisfies(
+            ex -> {
+              final var se = assertInstanceOf(ServiceException.class, ex);
+              assertEquals(413, se.errorCode());
+              assertTrue(se.getMessage().contains("exceeds limit"), "unexpected: " + ex);
+            })
+        .verify(TIMEOUT);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // control — streaming is never a single oversized payload
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("control: a streamed response (one frame per element) is unaffected by the limits")
+  void streamSucceeds() {
+    final var api = payloadService(0, WATERMARK, 0);
+
+    StepVerifier.create(api.streamItems(200)) // each element well under the watermark
+        .expectNextCount(200)
+        .expectComplete()
+        .verify(TIMEOUT);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // harness
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * Starts a provider and returns a client proxy.
+   *
+   * @param serverMtu server fragmentation MTU ({@code 0} = off)
+   * @param serverMaxMessageSize server high-watermark ({@code 0} = unbounded)
+   * @param clientMaxMessageSize client high-watermark / inbound reassembly cap ({@code 0} =
+   *     unbounded)
+   */
+  private PayloadService payloadService(
+      int serverMtu, int serverMaxMessageSize, int clientMaxMessageSize) {
+    // The two knobs under test live on RSocketServiceTransport — the normal place you configure the
+    // transport. Both are opt-in (default 0 = off = legacy behavior):
+    //   .mtu(n)            enable fragmentation so responses larger than the 16 MB frame cap can be
+    //                      sent in pieces.
+    //   .maxMessageSize(n) the high-watermark: a message larger than this fails fast while encoding
+    //                      with a 413 (streaming guard, never fully buffered), and inbound reassembly
+    //                      is capped at the same size (when n >= the frame cap). Set per node, so it
+    //                      must be configured on both the provider (here) and the caller (below).
+    service =
+        Microservices.start(
+            new Context()
+                .transport(
+                    () ->
+                        new RSocketServiceTransport()
+                            .mtu(serverMtu)
+                            .maxMessageSize(serverMaxMessageSize))
+                .services(new PayloadServiceImpl()));
+
+    serviceCall =
+        new ServiceCall()
+            .transport(
+                // Built directly here for an explicit per-call config; the production path is the
+                // same RSocketServiceTransport builder as above. The trailing two args are the same
+                // knobs at the low-level constructor: (..., mtu, maxMessageSize). mtu=0 (the client
+                // only sends tiny requests); maxMessageSize bounds the client's outgoing requests and
+                // caps inbound reassembly of responses it receives.
+                new RSocketClientTransport(
+                    HeadersCodec.DEFAULT_INSTANCE,
+                    DataCodec.getAllInstances(),
+                    RSocketClientTransportFactory.websocket().apply(LOOP_RESOURCE),
+                    null,
+                    null,
+                    0,
+                    clientMaxMessageSize))
+            .router(StaticAddressRouter.forService(service.serviceAddress(), "payloads").build());
+
+    return serviceCall.api(PayloadService.class);
+  }
+
+  @Service("v1/payloads")
+  public interface PayloadService {
+
+    /** Returns a response payload of exactly {@code size} bytes. */
+    @ServiceMethod("payload")
+    Mono<byte[]> getPayload(Integer size);
+
+    /** Returns a String of {@code length} chars (encoded data = {@code length + 2} bytes). */
+    @ServiceMethod("text")
+    Mono<String> getText(Integer length);
+
+    /** Echoes the size of the request payload (used to test the request-side guard). */
+    @ServiceMethod("upload")
+    Mono<Integer> upload(byte[] data);
+
+    /** Unbounded "fetch everything" query — the whole result as a single response payload. */
+    @ServiceMethod("items")
+    Mono<List<Item>> getItems(Integer count);
+
+    /** Same data, streamed one item per frame. */
+    @ServiceMethod("items/stream")
+    Flux<Item> streamItems(Integer count);
+  }
+
+  public static class PayloadServiceImpl implements PayloadService {
+
+    private static final String DATA = "x".repeat(1024); // ~1 KiB per item
+
+    @Override
+    public Mono<byte[]> getPayload(Integer size) {
+      return Mono.fromSupplier(() -> new byte[size]);
+    }
+
+    @Override
+    public Mono<String> getText(Integer length) {
+      return Mono.fromSupplier(() -> "x".repeat(length));
+    }
+
+    @Override
+    public Mono<Integer> upload(byte[] data) {
+      return Mono.just(data.length);
+    }
+
+    @Override
+    public Mono<List<Item>> getItems(Integer count) {
+      return Mono.fromSupplier(() -> items(count));
+    }
+
+    @Override
+    public Flux<Item> streamItems(Integer count) {
+      return Flux.fromIterable(items(count));
+    }
+
+    private static List<Item> items(int count) {
+      final var items = new ArrayList<Item>(count);
+      for (int i = 0; i < count; i++) {
+        items.add(new Item(i, DATA));
+      }
+      return items;
+    }
+  }
+
+  public static class Item {
+
+    private long id;
+    private String data;
+
+    public Item() {}
+
+    public Item(long id, String data) {
+      this.id = id;
+      this.data = data;
+    }
+
+    public long id() {
+      return id;
+    }
+
+    public String data() {
+      return data;
+    }
+  }
+}

--- a/services/src/test/java/io/scalecube/services/RSocketLargePayloadTest.java
+++ b/services/src/test/java/io/scalecube/services/RSocketLargePayloadTest.java
@@ -18,6 +18,8 @@ import io.scalecube.services.transport.rsocket.RSocketServiceTransport;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -83,6 +85,11 @@ final class RSocketLargePayloadTest {
 
   private Microservices service;
   private ServiceCall serviceCall;
+
+  @AfterAll
+  static void afterAll() {
+    LOOP_RESOURCE.disposeLater().block(TIMEOUT);
+  }
 
   @AfterEach
   void afterEach() {
@@ -239,6 +246,43 @@ final class RSocketLargePayloadTest {
         .verify(TIMEOUT);
   }
 
+  @Test
+  @DisplayName("stream: an oversized element terminates the stream with a 413")
+  void oversizedStreamElementTerminatesWith413() {
+    final var api = payloadService(0, WATERMARK, 0);
+
+    // 3 small elements are delivered, then the oversized 4th terminates the stream with the 413 —
+    // the responder stops there rather than encoding and sending anything after it.
+    StepVerifier.create(api.streamMixed(3))
+        .expectNextCount(3)
+        .expectErrorSatisfies(
+            ex -> {
+              final var se = assertInstanceOf(ServiceException.class, ex);
+              assertEquals(413, se.errorCode());
+              assertTrue(se.getMessage().contains("exceeds limit"), "unexpected: " + ex);
+            })
+        .verify(TIMEOUT);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // known gap (pinned, see ADR) — byte[] return types swallow the 413
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("known gap: a byte[]-typed method receives the 413 as raw bytes, not an error")
+  void byteArrayReturnSwallowsBusinessError() {
+    final var api = payloadService(0, WATERMARK, 0);
+
+    // Pre-existing scalecube quirk: ServiceMessageCodec.decodeData decodes a byte[]-typed response
+    // before checking isError(), so the 413 error body is handed to the caller as raw bytes with no
+    // exception. Pinned here so the gap is visible; flip this assertion when the isError-before-byte[]
+    // fix lands (tracked as a separate PR in the ADR).
+    final byte[] result = api.getPayload(WATERMARK + 1).block(TIMEOUT);
+    assertNotNull(result);
+    final String leaked = new String(result, StandardCharsets.UTF_8);
+    assertTrue(leaked.contains("exceeds limit"), "expected leaked error body, got: " + leaked);
+  }
+
   // ---------------------------------------------------------------------------------------------
   // harness
   // ---------------------------------------------------------------------------------------------
@@ -314,6 +358,10 @@ final class RSocketLargePayloadTest {
     /** Same data, streamed one item per frame. */
     @ServiceMethod("items/stream")
     Flux<Item> streamItems(Integer count);
+
+    /** Emits {@code smallCount} small elements, then one element larger than the watermark. */
+    @ServiceMethod("stream/mixed")
+    Flux<String> streamMixed(Integer smallCount);
   }
 
   public static class PayloadServiceImpl implements PayloadService {
@@ -343,6 +391,13 @@ final class RSocketLargePayloadTest {
     @Override
     public Flux<Item> streamItems(Integer count) {
       return Flux.fromIterable(items(count));
+    }
+
+    @Override
+    public Flux<String> streamMixed(Integer smallCount) {
+      return Flux.concat(
+          Flux.range(0, smallCount).map(i -> "x".repeat(64)),
+          Flux.just("x".repeat(1024 * 1024))); // 1 MiB element, far above the KB-scale watermark
     }
 
     private static List<Item> items(int count) {


### PR DESCRIPTION
## Problem

A service returned an unbounded result set as a single RSocket response. The encoded payload
exceeded RSocket's maximum single-frame length and the responder failed with:

```
io.rsocket.exceptions.CanceledException: The payload is too big to be send as a single frame
with a max frame length 16777215. Consider enabling fragmentation.
```

The gateway (the caller) relayed it to the client as a generic `errorCode: 500`. Two facts frame
the problem: the 16 MB single-frame cap is a fixed protocol constant (24-bit frame-length field),
and `scalecube-services` built the RSocket server/connector internally with no hook to configure
framing — so the fix has to live here.

## What this adds

Two opt-in knobs on `RSocketServiceTransport`, **both default `0` (off)** — existing behavior is
unchanged until you opt in:

- **`mtu(int)`** — enable RSocket fragmentation (server + client), so a response larger than the
  16 MB single-frame cap is split into frames and reassembled instead of failing.
- **`maxMessageSize(int)`** — a high-watermark on a single encoded message:
  - **Outbound:** encoding runs through a *streaming* guard (`LimitedOutputStream`) that aborts the
    instant the byte count would cross the limit — the oversized payload is never fully materialized
    (OOM-safe on send) and the caller gets a clean `413` ("Message size exceeds limit (N bytes)")
    instead of a cryptic `CanceledException`.
  - **Inbound:** when the watermark is at least the frame cap, it is also applied as RSocket's
    `maxInboundPayloadSize` on both ends, so a peer can't OOM the receiver during reassembly.

```java
new RSocketServiceTransport()
    .mtu(1 << 20)              // 1 MiB fragments -> can send responses past the 16 MB frame cap
    .maxMessageSize(32 << 20)  // 32 MiB ceiling -> fast 413, no OOM, no cryptic CanceledException
```

## How the size cases behave

| Response size | Outcome |
|---|---|
| within the single-frame cap | single frame, as today |
| over the frame cap, within the watermark | fragmented and delivered (needs `mtu`) |
| over the watermark | fail fast with `413`, never framed/fragmented/buffered |

## Compatibility

- Both knobs default to `0` = unbounded = exactly the prior behavior.
- The legacy `RSocketServerTransport` / `RSocketClientTransport` / `RSocketServiceAcceptor` /
  `RSocketClientChannel` / `RSocketImpl` constructors are preserved as overloads; the size-bounded
  encode path is only taken when a limit is set, so the default encode is byte-for-byte unchanged.
- Fragmentation on a sender is wire-compatible with any RSocket 1.1.x receiver (reassembly is always
  supported).

## Honest scope

These knobs bound serialization and reassembly. They **cannot** stop a service from OOMing while
building its own result objects before encoding — that still requires bounding the query
(pagination/streaming) at the service. The streaming test case shows that shape.

## Tests

- `LimitedOutputStreamTest` (5) — proves the streaming/abort-early guard is allocation-free (a
  would-be 8 GiB stream never buffers more than the limit).
- `RSocketLargePayloadTest` (9) — documented case matrix: frame-cap fail without fragmentation
  (asserts the exact RSocket message), fragmented success, watermark boundary (exact-at / one-over),
  `413` + exact message, realistic collection response aborted mid-encode, inbound-cap rejection,
  request-side guard, and a streaming control.

Full `services` + transport module suites: green, no regressions.

## Design

Recorded in `docs/adr/0001-rsocket-message-size-limits.md` (Status: Proposed) — context, alternatives
considered (bound-at-service / fragmentation-only / encode-then-measure / chosen), decision,
consequences, references.

## Follow-up (separate PR)

A pre-existing quirk surfaced: a `Mono<byte[]>` service method cannot receive error responses —
`ServiceMessageCodec.decodeData` decodes a `byte[]`-typed response before checking `isError()`, so a
`byte[]` client swallows error responses as raw bytes. Out of scope here; the fix is to compute the
target type (accounting for `isError`) before the `byte[]` branch.
